### PR TITLE
ci: add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,11 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install Redis CLI
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y redis-tools
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary

Add CI/CD pipeline using GitHub Actions.

## Workflow Jobs

### 1. Rust Tests
- Check code formatting with `cargo fmt`
- Run clippy lints
- Run Rust unit tests

### 2. Python Tests
- Uses `redis/redis-stack:latest` service for RedisJSON support
- Builds package with maturin
- Runs pytest integration tests

### 3. Build Wheels
- Matrix build across:
  - OS: ubuntu-latest, macos-latest
  - Python: 3.10, 3.11, 3.12
- Uploads wheel artifacts

## Notes

The workflow runs on pushes to master/main and on pull requests.