### PR TITLE
chore: update redis dependency to 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,19 +14,21 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 # Redis client
-redis = { version = "0.27", features = ["tokio-comp", "json", "cluster-async"] }
+redis = { version = "1.0", features = ["tokio-comp", "json", "cluster-async"] }
 tokio = { version = "1", features = ["rt-multi-thread", "sync"] }
 
 # Polars / Arrow
-polars = { version = "0.46", default-features = false, features = [
+polars = { version = "0.52", default-features = false, features = [
     "dtype-struct",
     "strings",
     "lazy",
+    "timezones",
+    "temporal",
 ] }
-arrow = { version = "54", default-features = false, features = ["ipc"] }
+arrow = { version = "57", default-features = false, features = ["ipc"] }
 
 # Python bindings (optional for pure Rust usage)
-pyo3 = { version = "0.23", features = ["extension-module"], optional = true }
+pyo3 = { version = "0.27", features = ["extension-module"], optional = true }
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
@@ -36,7 +38,7 @@ serde_json = "1.0"
 thiserror = "2.0"
 
 [build-dependencies]
-pyo3-build-config = "0.23"
+pyo3-build-config = "0.27"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,7 +206,7 @@ impl PyHashBatchIterator {
     ///
     /// Returns None when iteration is complete.
     /// Returns the RecordBatch serialized as Arrow IPC format.
-    fn next_batch_ipc(&mut self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn next_batch_ipc(&mut self, py: Python<'_>) -> PyResult<Option<Py<PyAny>>> {
         let batch = self
             .inner
             .next_batch()
@@ -351,7 +351,7 @@ impl PyJsonBatchIterator {
     ///
     /// Returns None when iteration is complete.
     /// Returns the RecordBatch serialized as Arrow IPC format.
-    fn next_batch_ipc(&mut self, py: Python<'_>) -> PyResult<Option<PyObject>> {
+    fn next_batch_ipc(&mut self, py: Python<'_>) -> PyResult<Option<Py<PyAny>>> {
         let batch = self
             .inner
             .next_batch()


### PR DESCRIPTION
## Summary

Update all dependencies to latest versions.

## Changes

| Dependency | Old | New |
|------------|-----|-----|
| redis | 0.27 | 1.0 |
| polars | 0.46 | 0.52 |
| arrow | 54 | 57 |
| pyo3 | 0.23 | 0.27 |
| pyo3-build-config | 0.23 | 0.27 |

## Notes

- Added `timezones` and `temporal` features to polars to work around [#25148](https://github.com/pola-rs/polars/issues/25148)
- Fixed deprecated `PyObject` -> `Py<PyAny>` for pyo3 0.27 compatibility

## Testing

- All 30 Rust tests pass
- All 40 Python tests pass
- Clippy and fmt checks pass