### PR TITLE
feat: add Date and Datetime Polars type support

### DIFF
--- a/python/polars_redis/__init__.py
+++ b/python/polars_redis/__init__.py
@@ -73,6 +73,8 @@ _DTYPE_MAP = {
     pl.Int64: "int64",
     pl.Float64: "float64",
     pl.Boolean: "bool",
+    pl.Date: "date",
+    pl.Datetime: "datetime",
 }
 
 
@@ -92,6 +94,10 @@ def _polars_dtype_to_internal(dtype: pl.DataType) -> str:
         return "float64"
     if "bool" in dtype_name:
         return "bool"
+    if "datetime" in dtype_name:
+        return "datetime"
+    if "date" in dtype_name:
+        return "date"
     raise ValueError(f"Unsupported dtype: {dtype}")
 
 
@@ -521,6 +527,8 @@ def _fields_to_schema(fields: list[tuple[str, str]]) -> dict[str, type[pl.DataTy
         "int64": pl.Int64,
         "float64": pl.Float64,
         "bool": pl.Boolean,
+        "date": pl.Date,
+        "datetime": pl.Datetime,
     }
     return {name: type_map.get(type_str, pl.Utf8) for name, type_str in fields}
 

--- a/src/infer.rs
+++ b/src/infer.rs
@@ -33,6 +33,8 @@ impl InferredSchema {
                     RedisType::Int64 => "int64",
                     RedisType::Float64 => "float64",
                     RedisType::Boolean => "bool",
+                    RedisType::Date => "date",
+                    RedisType::Datetime => "datetime",
                 };
                 (name.clone(), type_str.to_string())
             })


### PR DESCRIPTION
## Summary
Adds support for `pl.Date` and `pl.Datetime` Polars types when scanning Redis data.

## Changes
- Add `RedisType::Date` and `RedisType::Datetime` enum variants
- Map Date to Arrow Date32 (days since epoch)
- Map Datetime to Arrow Timestamp with microsecond precision
- Implement `parse_date()` supporting YYYY-MM-DD and epoch days
- Implement `parse_datetime()` supporting ISO 8601 and Unix timestamps (seconds/ms/us)
- Add `build_date_column()` and `build_datetime_column()` for RecordBatch conversion
- Update Python bindings to support `pl.Date` and `pl.Datetime`
- Add comprehensive unit tests for date/datetime parsing and conversion

## Example Usage
```python
import polars as pl
import polars_redis as redis

lf = redis.scan_hashes(
    "redis://localhost:6379",
    pattern="event:*",
    schema={
        "name": pl.Utf8,
        "event_date": pl.Date,        # Parses "2024-01-15" or epoch days
        "created_at": pl.Datetime,    # Parses ISO 8601 or Unix timestamps
    }
)
```

## Testing
- All 55 unit tests pass
- Clippy clean