### PR TITLE
feat: Phase 2 enhancements - TTL, row index, and better errors

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -65,6 +65,8 @@ polars-redis is a Polars IO plugin that enables scanning Redis data structures (
 | Null/missing field handling | ✅ Done | Missing fields become null |
 | Batched iteration | ✅ Done | Configurable batch_size and count_hint |
 | Include/exclude key column | ✅ Done | `include_key`, `key_column_name` options |
+| TTL column support | ✅ Done | `include_ttl`, `ttl_column_name` options |
+| Row index column support | ✅ Done | `include_row_index`, `row_index_column_name` options |
 | Python API (`register_io_source`) | ✅ Done | Full LazyFrame integration |
 | Integration tests | ✅ Done | 50+ Python tests, 42 Rust tests |
 | CI/CD pipeline | ✅ Done | GitHub Actions with Redis service |
@@ -75,7 +77,6 @@ polars-redis is a Polars IO plugin that enables scanning Redis data structures (
 
 | Feature | Priority | Phase |
 |---------|----------|-------|
-| TTL column support | Low | 2 |
 | Write modes (fail/replace/append) | Medium | 3 |
 | TTL on write | Medium | 3 |
 | Key generation strategies | Medium | 3 |
@@ -958,12 +959,11 @@ client-side for millions of members.
 ### Phase 2: Enhanced Read (Done)
 - [x] `read_hashes()` / `read_json()` eager functions
 - [x] `infer_hash_schema()` / `infer_json_schema()`
-- [ ] TTL column support
-- [ ] Row index support
-- [ ] Better error messages
-- [ ] PyPI release
+- [x] TTL column support
+- [x] Row index support
+- [x] Better error messages
 
-### Phase 3: Write Support (Done)
+### Phase 3: Write Support
 - [x] `write_hashes()` basic implementation
 - [x] `write_json()` basic implementation
 - [ ] Write modes (fail/replace/append)
@@ -982,6 +982,11 @@ client-side for millions of members.
 - [ ] Connection pooling
 - [ ] Cluster support
 - [ ] Lists support (`scan_list`)
+
+### Phase 6: Release
+- [ ] PyPI release
+- [ ] crates.io release
+- [ ] Documentation site
 
 ---
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,10 @@ impl PyHashBatchIterator {
     /// * `projection` - Optional list of columns to fetch
     /// * `include_key` - Whether to include the Redis key as a column
     /// * `key_column_name` - Name of the key column
+    /// * `include_ttl` - Whether to include the TTL as a column
+    /// * `ttl_column_name` - Name of the TTL column
+    /// * `include_row_index` - Whether to include the row index as a column
+    /// * `row_index_column_name` - Name of the row index column
     /// * `max_rows` - Optional maximum rows to return
     #[new]
     #[pyo3(signature = (
@@ -159,6 +163,10 @@ impl PyHashBatchIterator {
         projection = None,
         include_key = true,
         key_column_name = "_key".to_string(),
+        include_ttl = false,
+        ttl_column_name = "_ttl".to_string(),
+        include_row_index = false,
+        row_index_column_name = "_index".to_string(),
         max_rows = None
     ))]
     #[allow(clippy::too_many_arguments)]
@@ -171,6 +179,10 @@ impl PyHashBatchIterator {
         projection: Option<Vec<String>>,
         include_key: bool,
         key_column_name: String,
+        include_ttl: bool,
+        ttl_column_name: String,
+        include_row_index: bool,
+        row_index_column_name: String,
         max_rows: Option<usize>,
     ) -> PyResult<Self> {
         // Parse schema from Python types
@@ -195,7 +207,11 @@ impl PyHashBatchIterator {
 
         let hash_schema = HashSchema::new(field_types)
             .with_key(include_key)
-            .with_key_column_name(key_column_name);
+            .with_key_column_name(key_column_name)
+            .with_ttl(include_ttl)
+            .with_ttl_column_name(ttl_column_name)
+            .with_row_index(include_row_index)
+            .with_row_index_column_name(row_index_column_name);
 
         let mut config = BatchConfig::new(pattern)
             .with_batch_size(batch_size)
@@ -293,6 +309,10 @@ impl PyJsonBatchIterator {
     /// * `projection` - Optional list of columns to fetch
     /// * `include_key` - Whether to include the Redis key as a column
     /// * `key_column_name` - Name of the key column
+    /// * `include_ttl` - Whether to include the TTL as a column
+    /// * `ttl_column_name` - Name of the TTL column
+    /// * `include_row_index` - Whether to include the row index as a column
+    /// * `row_index_column_name` - Name of the row index column
     /// * `max_rows` - Optional maximum rows to return
     #[new]
     #[pyo3(signature = (
@@ -304,6 +324,10 @@ impl PyJsonBatchIterator {
         projection = None,
         include_key = true,
         key_column_name = "_key".to_string(),
+        include_ttl = false,
+        ttl_column_name = "_ttl".to_string(),
+        include_row_index = false,
+        row_index_column_name = "_index".to_string(),
         max_rows = None
     ))]
     #[allow(clippy::too_many_arguments)]
@@ -316,6 +340,10 @@ impl PyJsonBatchIterator {
         projection: Option<Vec<String>>,
         include_key: bool,
         key_column_name: String,
+        include_ttl: bool,
+        ttl_column_name: String,
+        include_row_index: bool,
+        row_index_column_name: String,
         max_rows: Option<usize>,
     ) -> PyResult<Self> {
         // Parse schema from Python type strings to Arrow DataTypes
@@ -340,7 +368,11 @@ impl PyJsonBatchIterator {
 
         let json_schema = JsonSchema::new(field_types)
             .with_key(include_key)
-            .with_key_column_name(key_column_name);
+            .with_key_column_name(key_column_name)
+            .with_ttl(include_ttl)
+            .with_ttl_column_name(ttl_column_name)
+            .with_row_index(include_row_index)
+            .with_row_index_column_name(row_index_column_name);
 
         let mut config = BatchConfig::new(pattern)
             .with_batch_size(batch_size)


### PR DESCRIPTION
## Summary

This PR completes Phase 2 of the polars-redis roadmap with three major enhancements:

### TTL Column Support
- New `include_ttl` and `ttl_column_name` parameters for `scan_hashes`, `scan_json`, `read_hashes`, and `read_json`
- Fetches TTL values using Redis `TTL` command with pipelining for efficiency
- Returns -1 for keys with no expiry, -2 for missing keys
- Uses `Int64` type for TTL values (seconds remaining)

### Row Index Column Support
- New `include_row_index` and `row_index_column_name` parameters
- Tracks row offset across batches for continuous indexing
- Uses `UInt64` type for row indices
- Useful for maintaining order or joining back to original data

### Improved Error Messages
- Connection errors now suggest checking Redis availability
- Invalid URL errors show expected format: `redis://[user:password@]host[:port][/db]`
- Type conversion errors show expected formats:
  - Int64: `Expected a valid integer (e.g., '42', '-100')`
  - Float64: `Expected a valid number (e.g., '3.14', '-0.5')`
  - Boolean: `Expected: true/false, yes/no, 1/0, t/f, y/n`
  - Date: `Expected: YYYY-MM-DD (e.g., '2024-01-15') or epoch days`
  - Datetime: `Expected: ISO 8601 (e.g., '2024-01-15T10:30:00') or Unix timestamp`
- Added new error types: `KeyNotFound`, `JsonModuleNotAvailable`

## Example Usage

```python
import polars as pl
import polars_redis as redis

# Scan with TTL and row index
lf = redis.scan_hashes(
    "redis://localhost:6379",
    pattern="user:*",
    schema={"name": pl.Utf8, "age": pl.Int64},
    include_ttl=True,
    include_row_index=True,
)

df = lf.collect()
# Columns: _index, _key, _ttl, name, age
```

## Testing
- All 65 Rust tests pass
- Python bindings verified with parameter inspection

## Files Changed
- `src/schema.rs` - HashSchema with TTL and row index fields
- `src/json_convert.rs` - JsonSchema with TTL and row index fields
- `src/arrow_convert.rs` - RecordBatch building with row offset
- `src/batch_iter.rs` - Row offset tracking across batches
- `src/json_batch_iter.rs` - Row offset tracking for JSON
- `src/hash_reader.rs` - TTL fetching with pipelining
- `src/json_reader.rs` - TTL fetching for JSON
- `src/error.rs` - Improved error messages and new types
- `src/lib.rs` - Python bindings for new parameters
- `python/polars_redis/__init__.py` - Python API updates
- `SPEC.md` - Updated to mark Phase 2 complete