### PR TITLE
feat: add TTL support to write operations

### DIFF
--- a/python/polars_redis/__init__.py
+++ b/python/polars_redis/__init__.py
@@ -609,6 +609,7 @@ def write_hashes(
     df: pl.DataFrame,
     url: str,
     key_column: str = "_key",
+    ttl: int | None = None,
 ) -> int:
     """Write a DataFrame to Redis as hashes.
 
@@ -619,6 +620,7 @@ def write_hashes(
         df: The DataFrame to write.
         url: Redis connection URL (e.g., "redis://localhost:6379").
         key_column: Column containing Redis keys (default: "_key").
+        ttl: Optional TTL in seconds for each key (default: None, no expiration).
 
     Returns:
         Number of keys successfully written.
@@ -634,6 +636,8 @@ def write_hashes(
         ... })
         >>> count = write_hashes(df, "redis://localhost:6379")
         >>> print(f"Wrote {count} hashes")
+        >>> # With TTL (expires in 1 hour)
+        >>> count = write_hashes(df, "redis://localhost:6379", ttl=3600)
     """
     if key_column not in df.columns:
         raise ValueError(f"Key column '{key_column}' not found in DataFrame")
@@ -657,7 +661,7 @@ def write_hashes(
         values.append(row_values)
 
     # Call the Rust implementation
-    keys_written, _ = py_write_hashes(url, keys, field_columns, values)
+    keys_written, _ = py_write_hashes(url, keys, field_columns, values, ttl)
     return keys_written
 
 
@@ -665,6 +669,7 @@ def write_json(
     df: pl.DataFrame,
     url: str,
     key_column: str = "_key",
+    ttl: int | None = None,
 ) -> int:
     """Write a DataFrame to Redis as JSON documents.
 
@@ -676,6 +681,7 @@ def write_json(
         df: The DataFrame to write.
         url: Redis connection URL (e.g., "redis://localhost:6379").
         key_column: Column containing Redis keys (default: "_key").
+        ttl: Optional TTL in seconds for each key (default: None, no expiration).
 
     Returns:
         Number of keys successfully written.
@@ -691,6 +697,8 @@ def write_json(
         ... })
         >>> count = write_json(df, "redis://localhost:6379")
         >>> print(f"Wrote {count} JSON documents")
+        >>> # With TTL (expires in 1 hour)
+        >>> count = write_json(df, "redis://localhost:6379", ttl=3600)
     """
     import json
 
@@ -715,7 +723,7 @@ def write_json(
         json_strings.append(json.dumps(doc))
 
     # Call the Rust implementation
-    keys_written, _ = py_write_json(url, keys, json_strings)
+    keys_written, _ = py_write_json(url, keys, json_strings, ttl)
     return keys_written
 
 
@@ -724,6 +732,7 @@ def write_strings(
     url: str,
     key_column: str = "_key",
     value_column: str = "value",
+    ttl: int | None = None,
 ) -> int:
     """Write a DataFrame to Redis as string values.
 
@@ -735,6 +744,7 @@ def write_strings(
         url: Redis connection URL (e.g., "redis://localhost:6379").
         key_column: Column containing Redis keys (default: "_key").
         value_column: Column containing values to write (default: "value").
+        ttl: Optional TTL in seconds for each key (default: None, no expiration).
 
     Returns:
         Number of keys successfully written.
@@ -749,6 +759,8 @@ def write_strings(
         ... })
         >>> count = write_strings(df, "redis://localhost:6379")
         >>> print(f"Wrote {count} strings")
+        >>> # With TTL (expires in 1 hour)
+        >>> count = write_strings(df, "redis://localhost:6379", ttl=3600)
     """
     if key_column not in df.columns:
         raise ValueError(f"Key column '{key_column}' not found in DataFrame")
@@ -768,5 +780,5 @@ def write_strings(
             values.append(str(val))
 
     # Call the Rust implementation
-    keys_written, _ = py_write_strings(url, keys, values)
+    keys_written, _ = py_write_strings(url, keys, values, ttl)
     return keys_written

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -546,17 +546,20 @@ fn py_infer_json_schema(
 /// * `keys` - List of Redis keys to write to
 /// * `fields` - List of field names
 /// * `values` - 2D list of values (rows x columns), same order as fields
+/// * `ttl` - Optional TTL in seconds for each key
 ///
 /// # Returns
 /// A tuple of (keys_written, keys_failed).
 #[pyfunction]
+#[pyo3(signature = (url, keys, fields, values, ttl = None))]
 fn py_write_hashes(
     url: &str,
     keys: Vec<String>,
     fields: Vec<String>,
     values: Vec<Vec<Option<String>>>,
+    ttl: Option<i64>,
 ) -> PyResult<(usize, usize)> {
-    let result = write_hashes(url, keys, fields, values)
+    let result = write_hashes(url, keys, fields, values, ttl)
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
 
     Ok((result.keys_written, result.keys_failed))
@@ -569,16 +572,19 @@ fn py_write_hashes(
 /// * `url` - Redis connection URL
 /// * `keys` - List of Redis keys to write to
 /// * `json_strings` - List of JSON strings to write
+/// * `ttl` - Optional TTL in seconds for each key
 ///
 /// # Returns
 /// A tuple of (keys_written, keys_failed).
 #[pyfunction]
+#[pyo3(signature = (url, keys, json_strings, ttl = None))]
 fn py_write_json(
     url: &str,
     keys: Vec<String>,
     json_strings: Vec<String>,
+    ttl: Option<i64>,
 ) -> PyResult<(usize, usize)> {
-    let result = write_json(url, keys, json_strings)
+    let result = write_json(url, keys, json_strings, ttl)
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
 
     Ok((result.keys_written, result.keys_failed))
@@ -591,16 +597,19 @@ fn py_write_json(
 /// * `url` - Redis connection URL
 /// * `keys` - List of Redis keys to write to
 /// * `values` - List of string values to write (None for null)
+/// * `ttl` - Optional TTL in seconds for each key
 ///
 /// # Returns
 /// A tuple of (keys_written, keys_failed).
 #[pyfunction]
+#[pyo3(signature = (url, keys, values, ttl = None))]
 fn py_write_strings(
     url: &str,
     keys: Vec<String>,
     values: Vec<Option<String>>,
+    ttl: Option<i64>,
 ) -> PyResult<(usize, usize)> {
-    let result = write_strings(url, keys, values)
+    let result = write_strings(url, keys, values, ttl)
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
 
     Ok((result.keys_written, result.keys_failed))


### PR DESCRIPTION
## Summary
Add optional TTL (time-to-live) parameter to all write functions.

## Changes
- Add `ttl: int | None` parameter to `write_hashes`, `write_json`, `write_strings`
- TTL is specified in seconds (None means no expiration)
- For strings, uses atomic `SETEX` command
- For hashes and JSON, uses `EXPIRE` after write

## Usage
```python
import polars as pl
import polars_redis

df = pl.DataFrame({
    "_key": ["user:1", "user:2"],
    "name": ["Alice", "Bob"],
})

# Write with 1 hour TTL
polars_redis.write_hashes(df, "redis://localhost:6379", ttl=3600)
```

## Testing
- All 65 Rust tests pass
- All Python tests pass
- Clippy clean