### PR TITLE
docs: Phase 4 documentation and examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,16 @@ name: CI
 on:
   push:
     branches: [master, main]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - ".github/workflows/docs.yml"
   pull_request:
     branches: [master, main]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - ".github/workflows/docs.yml"
 
 env:
   CARGO_TERM_COLOR: always

--- a/README.md
+++ b/README.md
@@ -1,17 +1,9 @@
 # polars-redis
 
-A [Polars](https://pola.rs/) IO plugin for scanning Redis data structures as LazyFrames with projection pushdown.
+A [Polars](https://pola.rs/) IO plugin for Redis. Scan Redis data structures as LazyFrames with projection pushdown, or write DataFrames back to Redis.
 
-[![PyPI](https://img.shields.io/pypi/v/polars-redis.svg)](https://pypi.org/project/polars-redis/)
+[![CI](https://github.com/joshrotenberg/polars-redis/actions/workflows/ci.yml/badge.svg)](https://github.com/joshrotenberg/polars-redis/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](LICENSE)
-
-## Features
-
-- **Lazy scanning** - Scan Redis hashes and JSON documents as Polars LazyFrames
-- **Projection pushdown** - Only fetch the fields you need (HMGET vs HGETALL)
-- **Batched iteration** - Efficiently handle large keyspaces with configurable batch sizes
-- **Type conversion** - Automatic schema-based parsing (strings, integers, floats, booleans)
-- **Null handling** - Missing fields become null values
 
 ## Installation
 
@@ -25,282 +17,51 @@ pip install polars-redis
 import polars as pl
 import polars_redis as redis
 
-# Scan Redis hashes matching a pattern
+# Scan hashes
 lf = redis.scan_hashes(
     "redis://localhost:6379",
     pattern="user:*",
-    schema={
-        "name": pl.Utf8,
-        "age": pl.Int64,
-        "score": pl.Float64,
-        "active": pl.Boolean,
-    }
-)
-
-# LazyFrame - nothing executed yet
-# Projection pushdown: only "name" and "age" are fetched from Redis
-result = (
-    lf
-    .filter(pl.col("age") > 30)
-    .select(["name", "age"])
-    .collect()
-)
-```
-
-## API Reference
-
-### Lazy Functions (Recommended)
-
-#### `scan_hashes()`
-
-Scan Redis hashes and return a LazyFrame.
-
-```python
-lf = redis.scan_hashes(
-    url="redis://localhost:6379",
-    pattern="user:*",                    # Key pattern (supports * and ?)
     schema={"name": pl.Utf8, "age": pl.Int64},
-    include_key=True,                    # Include Redis key as column
-    key_column_name="_key",              # Name of key column
-    batch_size=1000,                     # Keys per batch
-    count_hint=100,                      # SCAN COUNT hint
 )
+df = lf.filter(pl.col("age") > 30).collect()
+
+# Write back
+redis.write_hashes(df, "redis://localhost:6379", key_prefix="user:")
 ```
 
-#### `scan_json()`
+## Features
 
-Scan RedisJSON documents and return a LazyFrame.
+**Read:**
+- `scan_hashes()` / `read_hashes()` - Redis hashes
+- `scan_json()` / `read_json()` - RedisJSON documents
+- `scan_strings()` / `read_strings()` - Redis strings
+- Projection pushdown (HMGET vs HGETALL)
+- Schema inference (`infer_hash_schema()`, `infer_json_schema()`)
+- TTL and row index columns
 
-```python
-lf = redis.scan_json(
-    url="redis://localhost:6379",
-    pattern="doc:*",
-    schema={"title": pl.Utf8, "price": pl.Float64},
-)
-```
-
-### Eager Functions
-
-For convenience when you want a DataFrame immediately:
-
-```python
-# Returns DataFrame directly (calls .collect() internally)
-df = redis.read_hashes(url, pattern="user:*", schema=schema)
-df = redis.read_json(url, pattern="doc:*", schema=schema)
-```
-
-## Examples
-
-### Basic Hash Scanning
-
-```python
-import polars as pl
-import polars_redis as redis
-
-# Define schema for type conversion
-schema = {
-    "name": pl.Utf8,
-    "email": pl.Utf8,
-    "age": pl.Int64,
-    "score": pl.Float64,
-    "active": pl.Boolean,
-}
-
-# Scan all user hashes
-lf = redis.scan_hashes(
-    "redis://localhost:6379",
-    pattern="user:*",
-    schema=schema,
-)
-
-# Collect all data
-df = lf.collect()
-print(df)
-```
-
-### Projection Pushdown
-
-When you select specific columns, polars-redis uses `HMGET` instead of `HGETALL`, fetching only the fields you need:
-
-```python
-# Only fetches "name" and "age" fields from Redis
-df = (
-    redis.scan_hashes(url, pattern="user:*", schema=schema)
-    .select(["name", "age"])
-    .collect()
-)
-```
-
-### Filtering
-
-Filters are applied client-side after fetching:
-
-```python
-# Get active users over 30 with high scores
-df = (
-    redis.scan_hashes(url, pattern="user:*", schema=schema)
-    .filter(
-        (pl.col("age") > 30) &
-        (pl.col("active") == True) &
-        (pl.col("score") > 80)
-    )
-    .collect()
-)
-```
-
-### Aggregation
-
-```python
-# Average score by active status
-df = (
-    redis.scan_hashes(url, pattern="user:*", schema=schema)
-    .group_by("active")
-    .agg([
-        pl.len().alias("count"),
-        pl.col("age").mean().alias("avg_age"),
-        pl.col("score").mean().alias("avg_score"),
-    ])
-    .collect()
-)
-```
-
-### Limiting Results
-
-The `head()` operation stops iteration early:
-
-```python
-# Only scans until 10 rows are collected
-df = redis.scan_hashes(url, pattern="user:*", schema=schema).head(10).collect()
-```
-
-### Joining with Local Data
-
-```python
-# Scan users from Redis
-users = redis.scan_hashes(
-    url,
-    pattern="user:*",
-    schema={"name": pl.Utf8},
-    include_key=True,
-)
-
-# Local orders data
-orders = pl.DataFrame({
-    "user_key": ["user:1", "user:2", "user:3"],
-    "amount": [99.99, 149.50, 299.00],
-}).lazy()
-
-# Join on Redis key
-result = (
-    users
-    .join(orders, left_on="_key", right_on="user_key")
-    .collect()
-)
-```
-
-### JSON Documents
-
-```python
-# Scan RedisJSON documents
-lf = redis.scan_json(
-    "redis://localhost:6379",
-    pattern="product:*",
-    schema={
-        "name": pl.Utf8,
-        "category": pl.Utf8,
-        "price": pl.Float64,
-        "in_stock": pl.Boolean,
-    },
-)
-
-# Aggregate by category
-df = (
-    lf
-    .group_by("category")
-    .agg([
-        pl.col("price").mean().alias("avg_price"),
-        pl.len().alias("count"),
-    ])
-    .sort("avg_price", descending=True)
-    .collect()
-)
-```
+**Write:**
+- `write_hashes()`, `write_json()`, `write_strings()`
+- TTL support
+- Key prefix
+- Write modes: fail, replace, append
+- Auto-generate keys from row index
 
 ## Supported Types
 
-| Polars Type | Redis String Parsing |
-|-------------|---------------------|
-| `pl.Utf8` / `pl.String` | Pass-through |
-| `pl.Int64` | Parsed as integer |
-| `pl.Float64` | Parsed as float |
-| `pl.Boolean` | `true/false`, `1/0`, `yes/no`, `t/f`, `y/n` |
+| Polars | Redis |
+|--------|-------|
+| `Utf8` | string |
+| `Int64` | parsed int |
+| `Float64` | parsed float |
+| `Boolean` | true/false, 1/0, yes/no |
+| `Date` | YYYY-MM-DD or epoch days |
+| `Datetime` | ISO 8601 or Unix timestamp |
 
-## Performance Tips
-
-1. **Use projection pushdown** - Only include fields you need in your schema or use `.select()` to limit columns
-2. **Adjust batch_size** - Larger batches reduce round trips but use more memory
-3. **Use count_hint** - Higher values make SCAN return more keys per iteration
-4. **Use head()** - If you only need N rows, use `.head(N)` to stop early
-
-## Roadmap
-
-- [x] `scan_hashes()` - Lazy hash scanning
-- [x] `scan_json()` - Lazy JSON scanning  
-- [x] `read_hashes()` / `read_json()` - Eager variants
-- [x] Projection pushdown
-- [x] n_rows pushdown (head/limit)
-- [ ] Schema inference
-- [ ] Write support (`write_hashes()`, `write_json()`)
-- [ ] RediSearch predicate pushdown
-- [ ] Redis Streams support
-- [ ] RedisTimeSeries support
-
-## Development
-
-### Prerequisites
+## Requirements
 
 - Python 3.9+
-- Rust 1.70+
-- Redis 7.0+ (with RedisJSON module for JSON support)
-
-### Setup
-
-```bash
-# Clone the repository
-git clone https://github.com/joshrotenberg/polars-redis.git
-cd polars-redis
-
-# Create virtual environment
-python -m venv .venv
-source .venv/bin/activate
-
-# Install dependencies
-pip install maturin polars pytest
-
-# Build and install in development mode
-maturin develop
-
-# Run tests (requires Redis on localhost:6379)
-cargo test --lib --all-features
-pytest tests/ -v
-```
-
-### Running Lints
-
-```bash
-cargo fmt --all -- --check
-cargo clippy --all-targets --all-features -- -D warnings
-```
+- Redis 7.0+ (RedisJSON module for JSON support)
 
 ## License
 
-Licensed under either of:
-
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
-
-at your option.
-
-## Contributing
-
-Contributions are welcome! Please feel free to submit a Pull Request.
+MIT or Apache-2.0

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,153 +1,34 @@
-# polars-redis Examples
+# Examples
 
-This directory contains examples demonstrating how to use polars-redis to scan Redis data into Polars DataFrames.
+Examples for polars-redis in both Python and Rust.
 
 ## Prerequisites
 
-1. **Redis running locally** (or set `REDIS_URL` environment variable)
-   ```bash
-   # Using Docker
-   docker run -d --name redis -p 6379:6379 redis:latest
-   
-   # Or using redis-server directly
-   redis-server
-   ```
+- Redis running on localhost:6379
+- RedisJSON module for JSON examples
 
-2. **Sample data loaded**
-   ```bash
-   pip install redis
-   python setup_sample_data.py
-   ```
+## Python Examples
 
-## Examples
+See [python/README.md](python/README.md) for Python-specific examples.
 
-### Python Examples
-
-| File | Description |
-|------|-------------|
-| `python/setup_sample_data.py` | Creates sample user hashes and JSON docs in Redis |
-| `python/scan_hashes.py` | Comprehensive demo of hash scanning features |
-| `python/scan_json.py` | Demo of JSON document scanning |
-
-Run Python examples:
 ```bash
-cd examples/python
-python setup_sample_data.py
-python scan_hashes.py
-python scan_json.py
+pip install polars-redis
+python examples/python/basic_hashes.py
 ```
 
-### Rust Examples
+## Rust Examples
 
-| File | Description |
-|------|-------------|
-| `rust/scan_hashes.rs` | Direct Rust API usage for hash scanning |
-| `rust/scan_json.rs` | Direct Rust API for JSON document scanning |
+See [rust/](rust/) for Rust examples.
 
-Run Rust examples:
 ```bash
 cargo run --example scan_hashes
 cargo run --example scan_json
 ```
 
-## Environment Variables
+## Sample Data
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `REDIS_URL` | `redis://localhost:6379` | Redis connection URL |
-| `NUM_USERS` | `100` | Number of sample users to create |
-
-## Quick Start
+Use `python/setup_sample_data.py` to populate Redis with sample data for testing:
 
 ```bash
-# Terminal 1: Start Redis
-docker run -d --name redis -p 6379:6379 redis:latest
-
-# Terminal 2: Run examples
-pip install redis polars
-python setup_sample_data.py
-python scan_hashes.py
+python examples/python/setup_sample_data.py
 ```
-
-## Example Output
-
-```
-=== Example 1: Basic Hash Scanning ===
-
-LazyFrame schema: {'_key': String, 'name': String, 'email': String, 'age': Int64, 'score': Float64, 'active': Boolean}
-Type: <class 'polars.LazyFrame'>
-
-Collected 100 rows
-shape: (5, 6)
-┌─────────┬───────────────┬─────────────────────────────┬─────┬───────┬────────┐
-│ _key    ┆ name          ┆ email                       ┆ age ┆ score ┆ active │
-│ ---     ┆ ---           ┆ ---                         ┆ --- ┆ ---   ┆ ---    │
-│ str     ┆ str           ┆ str                         ┆ i64 ┆ f64   ┆ bool   │
-╞═════════╪═══════════════╪═════════════════════════════╪═════╪═══════╪════════╡
-│ user:1  ┆ Alice Smith   ┆ alice.smith1@gmail.com      ┆ 34  ┆ 87.5  ┆ true   │
-│ user:2  ┆ Bob Johnson   ┆ bob.johnson2@yahoo.com      ┆ 28  ┆ 62.3  ┆ true   │
-│ user:3  ┆ Charlie Brown ┆ charlie.brown3@outlook.com  ┆ 45  ┆ 91.2  ┆ false  │
-│ user:4  ┆ Diana Garcia  ┆ diana.garcia4@example.com   ┆ 31  ┆ 78.9  ┆ true   │
-│ user:5  ┆ Eve Wilson    ┆ eve.wilson5@test.org        ┆ 52  ┆ 45.6  ┆ true   │
-└─────────┴───────────────┴─────────────────────────────┴─────┴───────┴────────┘
-```
-
-## API Quick Reference
-
-### Python
-
-```python
-import polars as pl
-import polars_redis as redis
-
-# Basic scan - returns LazyFrame
-lf = redis.scan_hashes(
-    "redis://localhost:6379",
-    pattern="user:*",
-    schema={
-        "name": pl.Utf8,
-        "age": pl.Int64,
-    },
-    include_key=True,
-)
-
-# Use Polars operations
-result = (
-    lf
-    .filter(pl.col("age") > 30)
-    .select(["_key", "name", "age"])
-    .collect()
-)
-```
-
-### Rust
-
-```rust
-use polars_redis::{BatchConfig, HashBatchIterator, HashSchema, RedisType};
-
-let schema = HashSchema::new(vec![
-    ("name".to_string(), RedisType::Utf8),
-    ("age".to_string(), RedisType::Int64),
-])
-.with_key(true);
-
-let config = BatchConfig::new("user:*")
-    .with_batch_size(100);
-
-let mut iterator = HashBatchIterator::new(url, schema, config, None)?;
-
-while let Some(batch) = iterator.next_batch()? {
-    println!("Got {} rows", batch.num_rows());
-}
-```
-
-## Features Demonstrated
-
-- [x] Basic hash scanning
-- [x] Projection pushdown (HMGET optimization)
-- [x] Row limiting (n_rows / .head())
-- [x] Filtering and aggregation
-- [x] Joining Redis with local data
-- [x] Batch configuration
-- [x] Query plan inspection
-- [x] Error handling

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -1,0 +1,30 @@
+# Examples
+
+These examples demonstrate common polars-redis usage patterns.
+
+## Prerequisites
+
+- Redis running on localhost:6379
+- RedisJSON module for JSON examples
+- `pip install polars-redis`
+
+## Examples
+
+| File | Description |
+|------|-------------|
+| `basic_hashes.py` | Scanning and writing Redis hashes |
+| `json_documents.py` | Working with RedisJSON documents |
+| `schema_inference.py` | Automatic schema detection |
+| `strings_and_counters.py` | Redis strings and counters |
+| `ttl_and_metadata.py` | TTL and row index columns |
+| `write_modes.py` | Write modes: fail, replace, append |
+
+## Running
+
+```bash
+# Start Redis (with RedisJSON for JSON examples)
+docker run -d --name redis -p 6379:6379 redis/redis-stack
+
+# Run an example
+python examples/python/basic_hashes.py
+```

--- a/examples/python/basic_hashes.py
+++ b/examples/python/basic_hashes.py
@@ -1,0 +1,49 @@
+"""Basic example: scanning and writing Redis hashes."""
+
+import polars as pl
+import polars_redis as redis
+
+URL = "redis://localhost:6379"
+
+
+def main():
+    # Define schema
+    schema = {
+        "name": pl.Utf8,
+        "age": pl.Int64,
+        "score": pl.Float64,
+        "active": pl.Boolean,
+    }
+
+    # Scan hashes matching pattern
+    lf = redis.scan_hashes(URL, pattern="user:*", schema=schema)
+
+    # Filter and select (projection pushdown fetches only needed fields)
+    df = lf.filter(pl.col("age") > 25).select(["_key", "name", "age"]).collect()
+
+    print("Users over 25:")
+    print(df)
+
+    # Write new data back to Redis
+    new_users = pl.DataFrame(
+        {
+            "name": ["Charlie", "Diana"],
+            "age": [28, 35],
+            "score": [88.5, 92.0],
+            "active": [True, False],
+        }
+    )
+
+    # Auto-generate keys from row index
+    count = redis.write_hashes(
+        new_users,
+        URL,
+        key_column=None,
+        key_prefix="user:new:",
+        ttl=3600,  # 1 hour TTL
+    )
+    print(f"\nWrote {count} new hashes")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/json_documents.py
+++ b/examples/python/json_documents.py
@@ -1,0 +1,57 @@
+"""Example: working with RedisJSON documents."""
+
+import polars as pl
+import polars_redis as redis
+
+URL = "redis://localhost:6379"
+
+
+def main():
+    # Scan JSON documents
+    schema = {
+        "title": pl.Utf8,
+        "category": pl.Utf8,
+        "price": pl.Float64,
+        "in_stock": pl.Boolean,
+    }
+
+    lf = redis.scan_json(URL, pattern="product:*", schema=schema)
+
+    # Aggregate by category
+    summary = (
+        lf.group_by("category")
+        .agg(
+            [
+                pl.len().alias("count"),
+                pl.col("price").mean().alias("avg_price"),
+                pl.col("price").max().alias("max_price"),
+            ]
+        )
+        .sort("avg_price", descending=True)
+        .collect()
+    )
+
+    print("Products by category:")
+    print(summary)
+
+    # Write new products
+    products = pl.DataFrame(
+        {
+            "title": ["Widget", "Gadget"],
+            "category": ["tools", "electronics"],
+            "price": [19.99, 49.99],
+            "in_stock": [True, True],
+        }
+    )
+
+    count = redis.write_json(
+        products,
+        URL,
+        key_column=None,
+        key_prefix="product:",
+    )
+    print(f"\nWrote {count} products")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/schema_inference.py
+++ b/examples/python/schema_inference.py
@@ -1,0 +1,28 @@
+"""Example: automatic schema inference."""
+
+import polars_redis as redis
+
+URL = "redis://localhost:6379"
+
+
+def main():
+    # Infer schema from existing hashes
+    schema = redis.infer_hash_schema(URL, pattern="user:*", sample_size=100)
+    print("Inferred hash schema:")
+    for field, dtype in schema.items():
+        print(f"  {field}: {dtype}")
+
+    # Use inferred schema to scan
+    df = redis.read_hashes(URL, pattern="user:*", schema=schema)
+    print(f"\nLoaded {len(df)} rows")
+    print(df.head())
+
+    # Infer JSON schema
+    json_schema = redis.infer_json_schema(URL, pattern="product:*", sample_size=50)
+    print("\nInferred JSON schema:")
+    for field, dtype in json_schema.items():
+        print(f"  {field}: {dtype}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/strings_and_counters.py
+++ b/examples/python/strings_and_counters.py
@@ -1,0 +1,40 @@
+"""Example: working with Redis strings."""
+
+import polars as pl
+import polars_redis as redis
+
+URL = "redis://localhost:6379"
+
+
+def main():
+    # Scan string values as integers (counters)
+    lf = redis.scan_strings(
+        URL,
+        pattern="counter:*",
+        value_type=pl.Int64,
+    )
+
+    # Sum all counters
+    total = lf.select(pl.col("value").sum().alias("total")).collect()
+    print(f"Total count: {total['total'][0]}")
+
+    # Scan as strings for cache entries
+    cache = redis.read_strings(URL, pattern="cache:*")
+    print(f"\nCache entries: {len(cache)}")
+    print(cache.head())
+
+    # Write counters
+    counters = pl.DataFrame({"value": ["100", "200", "300"]})
+
+    count = redis.write_strings(
+        counters,
+        URL,
+        key_column=None,
+        key_prefix="counter:page:",
+        ttl=86400,  # 1 day TTL
+    )
+    print(f"\nWrote {count} counters")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/ttl_and_metadata.py
+++ b/examples/python/ttl_and_metadata.py
@@ -1,0 +1,36 @@
+"""Example: TTL and metadata columns."""
+
+import polars as pl
+import polars_redis as redis
+
+URL = "redis://localhost:6379"
+
+
+def main():
+    schema = {"name": pl.Utf8, "email": pl.Utf8}
+
+    # Include TTL and row index columns
+    lf = redis.scan_hashes(
+        URL,
+        pattern="user:*",
+        schema=schema,
+        include_key=True,
+        include_ttl=True,
+        include_row_index=True,
+    )
+
+    df = lf.collect()
+    print("Users with metadata:")
+    print(df)
+
+    # Find keys expiring soon (TTL < 1 hour)
+    expiring = df.filter((pl.col("_ttl") > 0) & (pl.col("_ttl") < 3600))
+    print(f"\nKeys expiring within 1 hour: {len(expiring)}")
+
+    # Keys without expiry (TTL = -1)
+    no_expiry = df.filter(pl.col("_ttl") == -1)
+    print(f"Keys without expiry: {len(no_expiry)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/write_modes.py
+++ b/examples/python/write_modes.py
@@ -1,0 +1,48 @@
+"""Example: write modes (fail, replace, append)."""
+
+import polars as pl
+import polars_redis as redis
+
+URL = "redis://localhost:6379"
+
+
+def main():
+    # Sample data
+    users = pl.DataFrame(
+        {
+            "_key": ["user:1", "user:2"],
+            "name": ["Alice", "Bob"],
+            "age": [30, 25],
+        }
+    )
+
+    # Replace mode (default): overwrites existing keys
+    count = redis.write_hashes(users, URL, if_exists="replace")
+    print(f"Replace mode: wrote {count} hashes")
+
+    # Fail mode: skips keys that already exist
+    count = redis.write_hashes(users, URL, if_exists="fail")
+    print(f"Fail mode: wrote {count} hashes (0 because keys exist)")
+
+    # Append mode: merges fields into existing hashes
+    updates = pl.DataFrame(
+        {
+            "_key": ["user:1", "user:2"],
+            "score": [95.5, 88.0],  # Add new field
+        }
+    )
+    count = redis.write_hashes(updates, URL, if_exists="append")
+    print(f"Append mode: updated {count} hashes with new field")
+
+    # Verify
+    df = redis.read_hashes(
+        URL,
+        pattern="user:*",
+        schema={"name": pl.Utf8, "age": pl.Int64, "score": pl.Float64},
+    )
+    print("\nFinal data:")
+    print(df)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rust/README.md
+++ b/examples/rust/README.md
@@ -1,0 +1,35 @@
+# Rust Examples
+
+These examples demonstrate the polars-redis Rust API directly.
+
+## Prerequisites
+
+- Redis running on localhost:6379
+- RedisJSON module for JSON examples
+- Sample data loaded
+
+## Examples
+
+| File | Description |
+|------|-------------|
+| `scan_hashes.rs` | Scanning Redis hashes with projection and batching |
+| `scan_json.rs` | Working with RedisJSON documents |
+| `scan_strings.rs` | Redis strings with different value types |
+| `schema_inference.rs` | Automatic schema detection |
+
+## Running
+
+```bash
+# Load sample data first
+python examples/python/setup_sample_data.py
+
+# Run examples
+cargo run --example scan_hashes
+cargo run --example scan_json
+cargo run --example scan_strings
+cargo run --example schema_inference
+```
+
+## Environment Variables
+
+- `REDIS_URL`: Override the default Redis connection URL (default: `redis://localhost:6379`)

--- a/examples/rust/scan_strings.rs
+++ b/examples/rust/scan_strings.rs
@@ -1,0 +1,147 @@
+//! Example: Scanning Redis strings with polars-redis.
+//!
+//! This example demonstrates how to use the Rust API to scan
+//! Redis string values and convert them to Arrow RecordBatches.
+//!
+//! Run with: cargo run --example scan_strings
+//!
+//! Prerequisites:
+//!     - Redis running on localhost:6379
+//!     - Sample data loaded (run setup_sample_data.py first)
+
+use polars_redis::{BatchConfig, RedisType, StringBatchIterator, StringSchema};
+use std::env;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let url = env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
+
+    println!("Connecting to: {}", url);
+    println!();
+
+    // =========================================================================
+    // Example 1: Scan string values as UTF-8
+    // =========================================================================
+    println!("=== Example 1: Scan Strings as UTF-8 ===\n");
+
+    let schema = StringSchema::new(RedisType::Utf8)
+        .with_key(true)
+        .with_key_column_name("_key")
+        .with_value_column_name("value");
+
+    let config = BatchConfig::new("cache:*").with_batch_size(100);
+
+    let mut iterator = StringBatchIterator::new(&url, schema, config)?;
+
+    let mut total_rows = 0;
+    while let Some(batch) = iterator.next_batch()? {
+        total_rows += batch.num_rows();
+
+        if total_rows <= batch.num_rows() {
+            println!("Schema:");
+            for field in batch.schema().fields() {
+                println!("  {:<12} : {:?}", field.name(), field.data_type());
+            }
+            println!();
+        }
+    }
+    println!("Total cache entries: {}\n", total_rows);
+
+    // =========================================================================
+    // Example 2: Scan counters as integers
+    // =========================================================================
+    println!("=== Example 2: Scan Counters as Int64 ===\n");
+
+    let schema = StringSchema::new(RedisType::Int64)
+        .with_key(true)
+        .with_value_column_name("count");
+
+    let config = BatchConfig::new("counter:*").with_batch_size(100);
+
+    let mut iterator = StringBatchIterator::new(&url, schema, config)?;
+
+    let mut total: i64 = 0;
+    let mut count = 0;
+
+    while let Some(batch) = iterator.next_batch()? {
+        count += batch.num_rows();
+
+        // Sum the counter values
+        let value_col = batch
+            .column_by_name("count")
+            .expect("count column should exist");
+
+        let values = value_col
+            .as_any()
+            .downcast_ref::<arrow::array::Int64Array>()
+            .expect("should be Int64Array");
+
+        total += values.iter().flatten().sum::<i64>();
+    }
+
+    println!("Counters found: {}", count);
+    println!("Sum of all counters: {}\n", total);
+
+    // =========================================================================
+    // Example 3: Scan float values
+    // =========================================================================
+    println!("=== Example 3: Scan Float Values ===\n");
+
+    let schema = StringSchema::new(RedisType::Float64)
+        .with_key(true)
+        .with_value_column_name("score");
+
+    let config = BatchConfig::new("score:*").with_batch_size(100);
+
+    let mut iterator = StringBatchIterator::new(&url, schema, config)?;
+
+    let mut sum: f64 = 0.0;
+    let mut count = 0;
+
+    while let Some(batch) = iterator.next_batch()? {
+        count += batch.num_rows();
+
+        let value_col = batch
+            .column_by_name("score")
+            .expect("score column should exist");
+
+        let values = value_col
+            .as_any()
+            .downcast_ref::<arrow::array::Float64Array>()
+            .expect("should be Float64Array");
+
+        sum += values.iter().flatten().sum::<f64>();
+    }
+
+    if count > 0 {
+        println!("Scores found: {}", count);
+        println!("Average score: {:.2}\n", sum / count as f64);
+    } else {
+        println!("No score keys found\n");
+    }
+
+    // =========================================================================
+    // Example 4: Without key column
+    // =========================================================================
+    println!("=== Example 4: Values Only (no key column) ===\n");
+
+    let schema = StringSchema::new(RedisType::Utf8)
+        .with_key(false)
+        .with_value_column_name("data");
+
+    let config = BatchConfig::new("cache:*")
+        .with_batch_size(10)
+        .with_max_rows(5);
+
+    let mut iterator = StringBatchIterator::new(&url, schema, config)?;
+
+    if let Some(batch) = iterator.next_batch()? {
+        println!("Columns (key excluded):");
+        for field in batch.schema().fields() {
+            println!("  {}", field.name());
+        }
+        println!("\nRows: {}", batch.num_rows());
+    }
+
+    println!("\n=== All examples complete ===");
+    Ok(())
+}

--- a/examples/rust/schema_inference.rs
+++ b/examples/rust/schema_inference.rs
@@ -1,0 +1,106 @@
+//! Example: Schema inference with polars-redis.
+//!
+//! This example demonstrates how to use schema inference to automatically
+//! detect field names and types from existing Redis data.
+//!
+//! Run with: cargo run --example schema_inference
+//!
+//! Prerequisites:
+//!     - Redis running on localhost:6379
+//!     - Sample data loaded (run setup_sample_data.py first)
+
+use polars_redis::infer::{infer_hash_schema, infer_json_schema};
+use std::env;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let url = env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
+
+    println!("Connecting to: {}", url);
+    println!();
+
+    // =========================================================================
+    // Example 1: Infer schema from Redis hashes
+    // =========================================================================
+    println!("=== Example 1: Infer Hash Schema ===\n");
+
+    let (fields, keys_sampled) = infer_hash_schema(&url, "user:*", 100, true)?;
+
+    println!("Sampled {} keys", keys_sampled);
+    println!("Inferred fields:");
+    for (name, type_str) in &fields {
+        println!("  {:<15} : {}", name, type_str);
+    }
+    println!();
+
+    // =========================================================================
+    // Example 2: Infer schema without type inference (all Utf8)
+    // =========================================================================
+    println!("=== Example 2: Infer Hash Schema (no type inference) ===\n");
+
+    let (fields, _) = infer_hash_schema(&url, "user:*", 50, false)?;
+
+    println!("Fields (all Utf8):");
+    for (name, type_str) in &fields {
+        println!("  {:<15} : {}", name, type_str);
+    }
+    println!();
+
+    // =========================================================================
+    // Example 3: Infer schema from RedisJSON documents
+    // =========================================================================
+    println!("=== Example 3: Infer JSON Schema ===\n");
+
+    let (fields, keys_sampled) = infer_json_schema(&url, "product:*", 100)?;
+
+    println!("Sampled {} keys", keys_sampled);
+    println!("Inferred fields:");
+    for (name, type_str) in &fields {
+        println!("  {:<15} : {}", name, type_str);
+    }
+    println!();
+
+    // =========================================================================
+    // Example 4: Use inferred schema to scan data
+    // =========================================================================
+    println!("=== Example 4: Scan Using Inferred Schema ===\n");
+
+    use polars_redis::{BatchConfig, HashBatchIterator, HashSchema, RedisType};
+
+    // First infer
+    let (fields, _) = infer_hash_schema(&url, "user:*", 50, true)?;
+
+    // Convert to HashSchema
+    let schema_fields: Vec<(String, RedisType)> = fields
+        .into_iter()
+        .map(|(name, type_str)| {
+            let redis_type = match type_str.as_str() {
+                "int64" => RedisType::Int64,
+                "float64" => RedisType::Float64,
+                "bool" => RedisType::Boolean,
+                "date" => RedisType::Date,
+                "datetime" => RedisType::Datetime,
+                _ => RedisType::Utf8,
+            };
+            (name, redis_type)
+        })
+        .collect();
+
+    let schema = HashSchema::new(schema_fields).with_key(true);
+
+    let config = BatchConfig::new("user:*")
+        .with_batch_size(100)
+        .with_max_rows(5);
+
+    let mut iterator = HashBatchIterator::new(&url, schema, config, None)?;
+
+    if let Some(batch) = iterator.next_batch()? {
+        println!("Scanned {} rows with inferred schema", batch.num_rows());
+        println!("Columns:");
+        for field in batch.schema().fields() {
+            println!("  {:<15} : {:?}", field.name(), field.data_type());
+        }
+    }
+
+    println!("\n=== All examples complete ===");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Phase 4: Documentation & Examples

## Changes

- Rewrite README to be concise (comprehensive docs site to come)
- Organize examples by language (`python/`, `rust/`)
- Add Python examples:
  - `basic_hashes.py` - Scanning and writing Redis hashes
  - `json_documents.py` - Working with RedisJSON documents
  - `schema_inference.py` - Automatic schema detection
  - `strings_and_counters.py` - Redis strings and counters
  - `ttl_and_metadata.py` - TTL and row index columns
  - `write_modes.py` - Write modes: fail, replace, append
- Add Rust examples:
  - `scan_strings.rs` - Redis strings with different value types
  - `schema_inference.rs` - Automatic schema detection
- Add CI path filtering to skip tests for docs-only changes (`**.md`, `docs/**`)

## Testing

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --lib --all-features` (82 tests pass)