### PR TITLE
docs: add Rust write examples

### DIFF
--- a/docs/examples/rust.md
+++ b/docs/examples/rust.md
@@ -5,10 +5,16 @@ Example code is in [`examples/rust/`](https://github.com/joshrotenberg/polars-re
 Run examples with:
 
 ```bash
+# Scan examples
 cargo run --example scan_hashes
 cargo run --example scan_json
 cargo run --example scan_strings
 cargo run --example schema_inference
+
+# Write examples
+cargo run --example write_hashes
+cargo run --example write_json
+cargo run --example write_strings
 ```
 
 ## Scan Hashes
@@ -41,4 +47,28 @@ Automatic schema detection from existing data:
 
 ```rust
 --8<-- "examples/rust/schema_inference.rs"
+```
+
+## Write Hashes
+
+Writing data to Redis as hashes:
+
+```rust
+--8<-- "examples/rust/write_hashes.rs"
+```
+
+## Write JSON
+
+Writing data to Redis as JSON documents:
+
+```rust
+--8<-- "examples/rust/write_json.rs"
+```
+
+## Write Strings
+
+Writing data to Redis as strings:
+
+```rust
+--8<-- "examples/rust/write_strings.rs"
 ```

--- a/examples/rust/README.md
+++ b/examples/rust/README.md
@@ -10,6 +10,8 @@ These examples demonstrate the polars-redis Rust API directly.
 
 ## Examples
 
+### Scanning
+
 | File | Description |
 |------|-------------|
 | `scan_hashes.rs` | Scanning Redis hashes with projection and batching |
@@ -17,17 +19,30 @@ These examples demonstrate the polars-redis Rust API directly.
 | `scan_strings.rs` | Redis strings with different value types |
 | `schema_inference.rs` | Automatic schema detection |
 
+### Writing
+
+| File | Description |
+|------|-------------|
+| `write_hashes.rs` | Writing data as Redis hashes |
+| `write_json.rs` | Writing data as RedisJSON documents |
+| `write_strings.rs` | Writing data as Redis strings |
+
 ## Running
 
 ```bash
-# Load sample data first
+# Load sample data for scan examples
 python examples/python/setup_sample_data.py
 
-# Run examples
+# Run scan examples
 cargo run --example scan_hashes
 cargo run --example scan_json
 cargo run --example scan_strings
 cargo run --example schema_inference
+
+# Run write examples (self-contained, cleanup after themselves)
+cargo run --example write_hashes
+cargo run --example write_json
+cargo run --example write_strings
 ```
 
 ## Environment Variables

--- a/examples/rust/write_hashes.rs
+++ b/examples/rust/write_hashes.rs
@@ -1,0 +1,169 @@
+//! Example: Writing hashes to Redis with polars-redis.
+//!
+//! This example demonstrates how to use the Rust API to write
+//! data to Redis as hashes.
+//!
+//! Run with: cargo run --example write_hashes
+//!
+//! Prerequisites:
+//!     - Redis running on localhost:6379
+
+use polars_redis::write::{WriteMode, write_hashes};
+use std::env;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let url = env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
+
+    println!("Connecting to: {}", url);
+    println!();
+
+    // =========================================================================
+    // Example 1: Basic hash writing
+    // =========================================================================
+    println!("=== Example 1: Basic Hash Writing ===\n");
+
+    let keys = vec![
+        "example:user:1".to_string(),
+        "example:user:2".to_string(),
+        "example:user:3".to_string(),
+    ];
+
+    let fields = vec!["name".to_string(), "age".to_string(), "city".to_string()];
+
+    let values = vec![
+        vec![
+            Some("Alice".to_string()),
+            Some("30".to_string()),
+            Some("NYC".to_string()),
+        ],
+        vec![
+            Some("Bob".to_string()),
+            Some("25".to_string()),
+            Some("LA".to_string()),
+        ],
+        vec![
+            Some("Carol".to_string()),
+            Some("35".to_string()),
+            Some("Chicago".to_string()),
+        ],
+    ];
+
+    let result = write_hashes(&url, keys, fields, values, None, WriteMode::Replace)?;
+
+    println!("Keys written: {}", result.keys_written);
+    println!("Keys failed: {}", result.keys_failed);
+    println!("Keys skipped: {}", result.keys_skipped);
+    println!();
+
+    // =========================================================================
+    // Example 2: Writing with TTL
+    // =========================================================================
+    println!("=== Example 2: Writing with TTL ===\n");
+
+    let keys = vec![
+        "example:session:1".to_string(),
+        "example:session:2".to_string(),
+    ];
+
+    let fields = vec!["user_id".to_string(), "token".to_string()];
+
+    let values = vec![
+        vec![Some("user:1".to_string()), Some("abc123".to_string())],
+        vec![Some("user:2".to_string()), Some("def456".to_string())],
+    ];
+
+    // TTL of 60 seconds
+    let result = write_hashes(&url, keys, fields, values, Some(60), WriteMode::Replace)?;
+
+    println!("Keys written with 60s TTL: {}", result.keys_written);
+    println!();
+
+    // =========================================================================
+    // Example 3: Fail mode (skip existing keys)
+    // =========================================================================
+    println!("=== Example 3: Fail Mode (Skip Existing) ===\n");
+
+    let keys = vec![
+        "example:user:1".to_string(), // Already exists from Example 1
+        "example:user:4".to_string(), // New key
+    ];
+
+    let fields = vec!["name".to_string(), "age".to_string()];
+
+    let values = vec![
+        vec![Some("Alice Updated".to_string()), Some("31".to_string())],
+        vec![Some("Dave".to_string()), Some("28".to_string())],
+    ];
+
+    let result = write_hashes(&url, keys, fields, values, None, WriteMode::Fail)?;
+
+    println!("Keys written: {}", result.keys_written);
+    println!("Keys skipped (already existed): {}", result.keys_skipped);
+    println!();
+
+    // =========================================================================
+    // Example 4: Append mode (merge fields)
+    // =========================================================================
+    println!("=== Example 4: Append Mode (Merge Fields) ===\n");
+
+    let keys = vec!["example:user:1".to_string()];
+
+    // Add new field to existing hash
+    let fields = vec!["email".to_string()];
+    let values = vec![vec![Some("alice@example.com".to_string())]];
+
+    let result = write_hashes(&url, keys, fields, values, None, WriteMode::Append)?;
+
+    println!("Keys updated with new field: {}", result.keys_written);
+    println!();
+
+    // =========================================================================
+    // Example 5: Handling null values
+    // =========================================================================
+    println!("=== Example 5: Handling Null Values ===\n");
+
+    let keys = vec!["example:partial:1".to_string()];
+
+    let fields = vec![
+        "required".to_string(),
+        "optional".to_string(),
+        "another".to_string(),
+    ];
+
+    // Some values are None - these fields will not be written
+    let values = vec![vec![
+        Some("present".to_string()),
+        None, // This field will be skipped
+        Some("also present".to_string()),
+    ]];
+
+    let result = write_hashes(&url, keys, fields, values, None, WriteMode::Replace)?;
+
+    println!("Keys written: {}", result.keys_written);
+    println!("(null values are skipped, only non-null fields written)");
+    println!();
+
+    // Cleanup
+    println!("=== Cleanup ===\n");
+    cleanup_example_keys(&url)?;
+    println!("Example keys deleted");
+
+    println!("\n=== All examples complete ===");
+    Ok(())
+}
+
+fn cleanup_example_keys(url: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let client = redis::Client::open(url)?;
+    let mut conn = client.get_connection()?;
+
+    let keys: Vec<String> = redis::cmd("KEYS")
+        .arg("example:*")
+        .query(&mut conn)
+        .unwrap_or_default();
+
+    if !keys.is_empty() {
+        redis::cmd("DEL").arg(&keys).query::<()>(&mut conn).ok();
+    }
+
+    Ok(())
+}

--- a/examples/rust/write_json.rs
+++ b/examples/rust/write_json.rs
@@ -1,0 +1,162 @@
+//! Example: Writing JSON documents to Redis with polars-redis.
+//!
+//! This example demonstrates how to use the Rust API to write
+//! data to Redis as JSON documents.
+//!
+//! Run with: cargo run --example write_json
+//!
+//! Prerequisites:
+//!     - Redis running on localhost:6379 with RedisJSON module
+
+use polars_redis::write::{WriteMode, write_json};
+use std::env;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let url = env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
+
+    println!("Connecting to: {}", url);
+    println!();
+
+    // =========================================================================
+    // Example 1: Basic JSON writing
+    // =========================================================================
+    println!("=== Example 1: Basic JSON Writing ===\n");
+
+    let keys = vec![
+        "example:doc:1".to_string(),
+        "example:doc:2".to_string(),
+        "example:doc:3".to_string(),
+    ];
+
+    let json_strings = vec![
+        r#"{"title": "Hello World", "views": 100, "published": true}"#.to_string(),
+        r#"{"title": "Getting Started", "views": 250, "published": true}"#.to_string(),
+        r#"{"title": "Draft Post", "views": 0, "published": false}"#.to_string(),
+    ];
+
+    let result = write_json(&url, keys, json_strings, None, WriteMode::Replace)?;
+
+    println!("Keys written: {}", result.keys_written);
+    println!("Keys failed: {}", result.keys_failed);
+    println!("Keys skipped: {}", result.keys_skipped);
+    println!();
+
+    // =========================================================================
+    // Example 2: Writing with TTL
+    // =========================================================================
+    println!("=== Example 2: Writing with TTL ===\n");
+
+    let keys = vec!["example:cache:1".to_string(), "example:cache:2".to_string()];
+
+    let json_strings = vec![
+        r#"{"data": "cached value 1", "timestamp": 1704067200}"#.to_string(),
+        r#"{"data": "cached value 2", "timestamp": 1704067200}"#.to_string(),
+    ];
+
+    // TTL of 300 seconds (5 minutes)
+    let result = write_json(&url, keys, json_strings, Some(300), WriteMode::Replace)?;
+
+    println!("Keys written with 5min TTL: {}", result.keys_written);
+    println!();
+
+    // =========================================================================
+    // Example 3: Fail mode (skip existing keys)
+    // =========================================================================
+    println!("=== Example 3: Fail Mode (Skip Existing) ===\n");
+
+    let keys = vec![
+        "example:doc:1".to_string(), // Already exists from Example 1
+        "example:doc:4".to_string(), // New key
+    ];
+
+    let json_strings = vec![
+        r#"{"title": "Updated Title", "views": 999}"#.to_string(),
+        r#"{"title": "New Document", "views": 50}"#.to_string(),
+    ];
+
+    let result = write_json(&url, keys, json_strings, None, WriteMode::Fail)?;
+
+    println!("Keys written: {}", result.keys_written);
+    println!("Keys skipped (already existed): {}", result.keys_skipped);
+    println!();
+
+    // =========================================================================
+    // Example 4: Nested JSON structures
+    // =========================================================================
+    println!("=== Example 4: Nested JSON Structures ===\n");
+
+    let keys = vec!["example:complex:1".to_string()];
+
+    let json_strings = vec![
+        r#"{
+        "user": {
+            "name": "Alice",
+            "email": "alice@example.com"
+        },
+        "tags": ["rust", "redis", "polars"],
+        "metadata": {
+            "created": "2024-01-15",
+            "version": 1
+        }
+    }"#
+        .to_string(),
+    ];
+
+    let result = write_json(&url, keys, json_strings, None, WriteMode::Replace)?;
+
+    println!("Keys written: {}", result.keys_written);
+    println!("(nested structures are stored as-is)");
+    println!();
+
+    // =========================================================================
+    // Example 5: Programmatic JSON construction
+    // =========================================================================
+    println!("=== Example 5: Programmatic JSON Construction ===\n");
+
+    use std::collections::HashMap;
+
+    let mut data: Vec<(String, String)> = Vec::new();
+
+    for i in 1..=5 {
+        let key = format!("example:product:{}", i);
+        let mut product: HashMap<&str, serde_json::Value> = HashMap::new();
+        product.insert("id", serde_json::json!(i));
+        product.insert("name", serde_json::json!(format!("Product {}", i)));
+        product.insert("price", serde_json::json!(i as f64 * 9.99));
+        product.insert("in_stock", serde_json::json!(i % 2 == 0));
+
+        let json_str = serde_json::to_string(&product)?;
+        data.push((key, json_str));
+    }
+
+    let (keys, json_strings): (Vec<_>, Vec<_>) = data.into_iter().unzip();
+
+    let result = write_json(&url, keys, json_strings, None, WriteMode::Replace)?;
+
+    println!("Keys written: {}", result.keys_written);
+    println!();
+
+    // Cleanup
+    println!("=== Cleanup ===\n");
+    cleanup_example_keys(&url)?;
+    println!("Example keys deleted");
+
+    println!("\n=== All examples complete ===");
+    Ok(())
+}
+
+fn cleanup_example_keys(url: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let client = redis::Client::open(url)?;
+    let mut conn = client.get_connection()?;
+
+    let keys: Vec<String> = redis::cmd("KEYS")
+        .arg("example:*")
+        .query(&mut conn)
+        .unwrap_or_default();
+
+    if !keys.is_empty() {
+        redis::cmd("DEL").arg(&keys).query::<()>(&mut conn).ok();
+    }
+
+    Ok(())
+}

--- a/examples/rust/write_strings.rs
+++ b/examples/rust/write_strings.rs
@@ -1,0 +1,168 @@
+//! Example: Writing strings to Redis with polars-redis.
+//!
+//! This example demonstrates how to use the Rust API to write
+//! data to Redis as string values.
+//!
+//! Run with: cargo run --example write_strings
+//!
+//! Prerequisites:
+//!     - Redis running on localhost:6379
+
+use polars_redis::write::{WriteMode, write_strings};
+use std::env;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let url = env::var("REDIS_URL").unwrap_or_else(|_| "redis://localhost:6379".to_string());
+
+    println!("Connecting to: {}", url);
+    println!();
+
+    // =========================================================================
+    // Example 1: Basic string writing
+    // =========================================================================
+    println!("=== Example 1: Basic String Writing ===\n");
+
+    let keys = vec![
+        "example:counter:1".to_string(),
+        "example:counter:2".to_string(),
+        "example:counter:3".to_string(),
+    ];
+
+    let values = vec![
+        Some("100".to_string()),
+        Some("200".to_string()),
+        Some("300".to_string()),
+    ];
+
+    let result = write_strings(&url, keys, values, None, WriteMode::Replace)?;
+
+    println!("Keys written: {}", result.keys_written);
+    println!("Keys failed: {}", result.keys_failed);
+    println!("Keys skipped: {}", result.keys_skipped);
+    println!();
+
+    // =========================================================================
+    // Example 2: Writing with TTL
+    // =========================================================================
+    println!("=== Example 2: Writing with TTL ===\n");
+
+    let keys = vec!["example:temp:1".to_string(), "example:temp:2".to_string()];
+
+    let values = vec![
+        Some("temporary value 1".to_string()),
+        Some("temporary value 2".to_string()),
+    ];
+
+    // TTL of 120 seconds (2 minutes)
+    let result = write_strings(&url, keys, values, Some(120), WriteMode::Replace)?;
+
+    println!("Keys written with 2min TTL: {}", result.keys_written);
+    println!();
+
+    // =========================================================================
+    // Example 3: Fail mode (skip existing keys)
+    // =========================================================================
+    println!("=== Example 3: Fail Mode (Skip Existing) ===\n");
+
+    let keys = vec![
+        "example:counter:1".to_string(), // Already exists from Example 1
+        "example:counter:4".to_string(), // New key
+    ];
+
+    let values = vec![Some("999".to_string()), Some("400".to_string())];
+
+    let result = write_strings(&url, keys, values, None, WriteMode::Fail)?;
+
+    println!("Keys written: {}", result.keys_written);
+    println!("Keys skipped (already existed): {}", result.keys_skipped);
+    println!();
+
+    // =========================================================================
+    // Example 4: Handling null values
+    // =========================================================================
+    println!("=== Example 4: Handling Null Values ===\n");
+
+    let keys = vec![
+        "example:value:1".to_string(),
+        "example:value:2".to_string(),
+        "example:value:3".to_string(),
+    ];
+
+    // Some values are None - these keys will not be written
+    let values = vec![
+        Some("present".to_string()),
+        None, // This key will be skipped
+        Some("also present".to_string()),
+    ];
+
+    let result = write_strings(&url, keys, values, None, WriteMode::Replace)?;
+
+    println!("Keys written: {}", result.keys_written);
+    println!("(null values are skipped)");
+    println!();
+
+    // =========================================================================
+    // Example 5: Writing various data types as strings
+    // =========================================================================
+    println!("=== Example 5: Various Data Types as Strings ===\n");
+
+    let keys = vec![
+        "example:int".to_string(),
+        "example:float".to_string(),
+        "example:bool".to_string(),
+        "example:json".to_string(),
+    ];
+
+    let values = vec![
+        Some("42".to_string()),
+        Some("3.14159".to_string()),
+        Some("true".to_string()),
+        Some(r#"{"nested": "data"}"#.to_string()),
+    ];
+
+    let result = write_strings(&url, keys, values, None, WriteMode::Replace)?;
+
+    println!("Keys written: {}", result.keys_written);
+    println!("(all values stored as strings, can be parsed on read)");
+    println!();
+
+    // =========================================================================
+    // Example 6: Batch writing
+    // =========================================================================
+    println!("=== Example 6: Batch Writing ===\n");
+
+    let count = 100;
+    let keys: Vec<String> = (0..count).map(|i| format!("example:batch:{}", i)).collect();
+    let values: Vec<Option<String>> = (0..count).map(|i| Some(format!("value_{}", i))).collect();
+
+    let result = write_strings(&url, keys, values, None, WriteMode::Replace)?;
+
+    println!("Batch size: {}", count);
+    println!("Keys written: {}", result.keys_written);
+    println!("(writes are automatically pipelined for performance)");
+    println!();
+
+    // Cleanup
+    println!("=== Cleanup ===\n");
+    cleanup_example_keys(&url)?;
+    println!("Example keys deleted");
+
+    println!("\n=== All examples complete ===");
+    Ok(())
+}
+
+fn cleanup_example_keys(url: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let client = redis::Client::open(url)?;
+    let mut conn = client.get_connection()?;
+
+    let keys: Vec<String> = redis::cmd("KEYS")
+        .arg("example:*")
+        .query(&mut conn)
+        .unwrap_or_default();
+
+    if !keys.is_empty() {
+        redis::cmd("DEL").arg(&keys).query::<()>(&mut conn).ok();
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Add Rust examples for write operations to match the Python examples.

## Changes

- **write_hashes.rs**: Writing data as Redis hashes with TTL, fail mode, append mode
- **write_json.rs**: Writing JSON documents including nested structures
- **write_strings.rs**: Writing string values with batch demonstration
- Updated examples README with write examples section
- Updated docs site examples page

## Examples

All write examples are self-contained and clean up after themselves:

```bash
cargo run --example write_hashes
cargo run --example write_json
cargo run --example write_strings
```