### PR TITLE
fix: use config file for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,5 +19,5 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          release-type: rust
-          package-name: polars-redis
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json


### PR DESCRIPTION
Fixes the release-please workflow to use config-file and manifest-file parameters instead of deprecated inline parameters.