### PR TITLE
fix: use macos-14 for Intel cross-compile

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,8 +28,8 @@ jobs:
           # Linux aarch64 (uses QEMU emulation via maturin-action)
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-          # macOS x86_64 (Intel)
-          - os: macos-13-large
+          # macOS x86_64 (Intel) - cross-compile from ARM
+          - os: macos-14
             target: x86_64-apple-darwin
           # macOS aarch64 (Apple Silicon)
           - os: macos-14
@@ -102,6 +102,8 @@ jobs:
   publish-crates:
     name: Publish to crates.io
     runs-on: ubuntu-latest
+    # Don't fail if crate already published
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

Fixes macOS Intel wheel builds after macos-13 retirement.

## Changes

- Cross-compile x86_64-apple-darwin from macos-14 (ARM runner) instead of using retired macos-13
- Add `continue-on-error: true` to crates.io publish so re-runs don't fail if already published

The maturin-action can cross-compile Intel binaries from ARM macOS.