### PR TITLE
ci: add performance regression tracking

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,6 +1,20 @@
 name: Benchmarks
 
 on:
+  push:
+    branches: [master]
+    paths:
+      - "src/**"
+      - "benches/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+  pull_request:
+    branches: [master]
+    paths:
+      - "src/**"
+      - "benches/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
   schedule:
     # Run daily at 2 AM UTC
     - cron: "0 2 * * *"
@@ -8,6 +22,10 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   benchmarks:
@@ -31,11 +49,32 @@ jobs:
             ${{ runner.os }}-cargo-bench-
 
       - name: Run benchmarks
-        run: cargo bench --features search -- --noplot
+        run: cargo bench --bench benchmarks --features search -- --noplot --output-format bencher | tee output.txt
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Rust Benchmarks
+          tool: cargo
+          output-file-path: output.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Only push to gh-pages on master
+          auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          # Alert if performance regresses by more than 15%
+          alert-threshold: "115%"
+          # Comment on commit/PR when alert threshold exceeded
+          comment-on-alert: true
+          # Don't fail the workflow on regression (just warn)
+          fail-on-alert: false
+          # Store benchmark data in gh-pages branch
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench
 
       - name: Upload benchmark results
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-results
-          path: target/criterion
+          path: |
+            target/criterion
+            output.txt
           retention-days: 30


### PR DESCRIPTION
## Summary

Add automated performance regression tracking to the CI pipeline, completing the final item from #43.

## Changes to `.github/workflows/benchmarks.yml`

### Triggers
- **Push to master**: Run benchmarks and store baseline
- **PRs**: Run benchmarks and compare against baseline (on changes to src/, benches/, Cargo.*)
- **Daily schedule**: Catch environmental drift
- **Manual dispatch**: On-demand runs

### Features
- Uses [github-action-benchmark](https://github.com/benchmark-action/github-action-benchmark) for tracking
- Stores historical benchmark data in `gh-pages` branch under `dev/bench/`
- **Alert threshold**: Comments on PR/commit if performance regresses by >15%
- **Non-blocking**: Alerts are warnings, not failures (to avoid blocking PRs for minor regressions)
- Uploads criterion results as artifacts (30-day retention)

### How It Works

1. On push to master, benchmarks run and results are stored in gh-pages
2. On PRs, benchmarks run and compare against the stored baseline
3. If any benchmark regresses by more than 15%, a comment is posted
4. Historical data can be viewed at the benchmark dashboard (once gh-pages is set up)

## Example Alert

When a regression is detected, the action comments:
```
Performance Alert

Possible performance regression detected:
- schema_creation/small_3_fields: 150ns -> 180ns (+20%)
```

## Note

The first run on master will establish the baseline. Subsequent PRs will compare against it.

Closes #43