### PR TITLE
feat: add TTL support for String type reads

### DIFF
--- a/python/polars_redis/_read.py
+++ b/python/polars_redis/_read.py
@@ -20,6 +20,8 @@ def read_strings(
     include_key: bool = True,
     key_column_name: str = "_key",
     value_column_name: str = "value",
+    include_ttl: bool = False,
+    ttl_column_name: str = "_ttl",
     batch_size: int = 1000,
     count_hint: int = 100,
 ) -> pl.DataFrame:
@@ -35,6 +37,8 @@ def read_strings(
         include_key: Whether to include the Redis key as a column.
         key_column_name: Name of the key column (default: "_key").
         value_column_name: Name of the value column (default: "value").
+        include_ttl: Whether to include the TTL as a column.
+        ttl_column_name: Name of the TTL column (default: "_ttl").
         batch_size: Number of keys to process per batch.
         count_hint: SCAN COUNT hint for Redis.
 
@@ -55,6 +59,8 @@ def read_strings(
         include_key=include_key,
         key_column_name=key_column_name,
         value_column_name=value_column_name,
+        include_ttl=include_ttl,
+        ttl_column_name=ttl_column_name,
         batch_size=batch_size,
         count_hint=count_hint,
     ).collect()

--- a/python/polars_redis/options.py
+++ b/python/polars_redis/options.py
@@ -284,6 +284,7 @@ class StringScanOptions:
         >>> opts = StringScanOptions(
         ...     pattern="counter:*",
         ...     value_column_name="count",
+        ...     include_ttl=True,
         ... )
 
     Attributes:
@@ -294,6 +295,8 @@ class StringScanOptions:
         include_key: Whether to include the Redis key as a column.
         key_column_name: Name of the key column.
         value_column_name: Name of the value column.
+        include_ttl: Whether to include the TTL as a column.
+        ttl_column_name: Name of the TTL column.
         include_row_index: Whether to include the row index as a column.
         row_index_column_name: Name of the row index column.
         row_index_offset: Starting offset for the row index.
@@ -306,6 +309,8 @@ class StringScanOptions:
     include_key: bool = True
     key_column_name: str = "_key"
     value_column_name: str = "value"
+    include_ttl: bool = False
+    ttl_column_name: str = "_ttl"
     include_row_index: bool = False
     row_index_column_name: str = "_index"
     row_index_offset: int = 0
@@ -340,6 +345,13 @@ class StringScanOptions:
     def with_value_column_name(self, name: str) -> StringScanOptions:
         """Set the value column name."""
         self.value_column_name = name
+        return self
+
+    def with_ttl(self, include: bool = True, name: str | None = None) -> StringScanOptions:
+        """Configure the TTL column."""
+        self.include_ttl = include
+        if name is not None:
+            self.ttl_column_name = name
         return self
 
     def with_row_index(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -792,6 +792,8 @@ impl PyClusterStringBatchIterator {
         include_key = true,
         key_column_name = "_key".to_string(),
         value_column_name = "value".to_string(),
+        include_ttl = false,
+        ttl_column_name = "_ttl".to_string(),
         max_rows = None,
         parallel = None
     ))]
@@ -805,6 +807,8 @@ impl PyClusterStringBatchIterator {
         include_key: bool,
         key_column_name: String,
         value_column_name: String,
+        include_ttl: bool,
+        ttl_column_name: String,
         max_rows: Option<usize>,
         parallel: Option<usize>,
     ) -> PyResult<Self> {
@@ -828,7 +832,9 @@ impl PyClusterStringBatchIterator {
         let string_schema = StringSchema::new(dtype)
             .with_key(include_key)
             .with_key_column_name(key_column_name)
-            .with_value_column_name(value_column_name);
+            .with_value_column_name(value_column_name)
+            .with_ttl(include_ttl)
+            .with_ttl_column_name(ttl_column_name);
 
         let mut config = BatchConfig::new(pattern)
             .with_batch_size(batch_size)
@@ -1566,6 +1572,8 @@ impl PyStringBatchIterator {
     /// * `include_key` - Whether to include the Redis key as a column
     /// * `key_column_name` - Name of the key column
     /// * `value_column_name` - Name of the value column
+    /// * `include_ttl` - Whether to include the TTL as a column
+    /// * `ttl_column_name` - Name of the TTL column
     /// * `max_rows` - Optional maximum rows to return
     /// * `parallel` - Optional number of parallel workers for fetching
     #[new]
@@ -1578,6 +1586,8 @@ impl PyStringBatchIterator {
         include_key = true,
         key_column_name = "_key".to_string(),
         value_column_name = "value".to_string(),
+        include_ttl = false,
+        ttl_column_name = "_ttl".to_string(),
         max_rows = None,
         parallel = None
     ))]
@@ -1591,6 +1601,8 @@ impl PyStringBatchIterator {
         include_key: bool,
         key_column_name: String,
         value_column_name: String,
+        include_ttl: bool,
+        ttl_column_name: String,
         max_rows: Option<usize>,
         parallel: Option<usize>,
     ) -> PyResult<Self> {
@@ -1615,7 +1627,9 @@ impl PyStringBatchIterator {
         let string_schema = StringSchema::new(dtype)
             .with_key(include_key)
             .with_key_column_name(key_column_name)
-            .with_value_column_name(value_column_name);
+            .with_value_column_name(value_column_name)
+            .with_ttl(include_ttl)
+            .with_ttl_column_name(ttl_column_name);
 
         let mut config = BatchConfig::new(pattern)
             .with_batch_size(batch_size)

--- a/src/types/string/convert.rs
+++ b/src/types/string/convert.rs
@@ -25,6 +25,10 @@ pub struct StringSchema {
     key_column_name: String,
     /// Name of the value column.
     value_column_name: String,
+    /// Whether to include the TTL as a column.
+    include_ttl: bool,
+    /// Name of the TTL column.
+    ttl_column_name: String,
 }
 
 impl StringSchema {
@@ -35,6 +39,8 @@ impl StringSchema {
             include_key: true,
             key_column_name: "_key".to_string(),
             value_column_name: "value".to_string(),
+            include_ttl: false,
+            ttl_column_name: "_ttl".to_string(),
         }
     }
 
@@ -53,6 +59,18 @@ impl StringSchema {
     /// Set the name of the value column.
     pub fn with_value_column_name(mut self, name: impl Into<String>) -> Self {
         self.value_column_name = name.into();
+        self
+    }
+
+    /// Set whether to include the TTL as a column.
+    pub fn with_ttl(mut self, include: bool) -> Self {
+        self.include_ttl = include;
+        self
+    }
+
+    /// Set the name of the TTL column.
+    pub fn with_ttl_column_name(mut self, name: impl Into<String>) -> Self {
+        self.ttl_column_name = name.into();
         self
     }
 
@@ -76,12 +94,26 @@ impl StringSchema {
         &self.value_column_name
     }
 
+    /// Whether the TTL column is included.
+    pub fn include_ttl(&self) -> bool {
+        self.include_ttl
+    }
+
+    /// Get the TTL column name.
+    pub fn ttl_column_name(&self) -> &str {
+        &self.ttl_column_name
+    }
+
     /// Convert to Arrow Schema.
     pub fn to_arrow_schema(&self) -> Schema {
-        let mut fields = Vec::with_capacity(2);
+        let mut fields = Vec::with_capacity(3);
 
         if self.include_key {
             fields.push(Field::new(&self.key_column_name, DataType::Utf8, false));
+        }
+
+        if self.include_ttl {
+            fields.push(Field::new(&self.ttl_column_name, DataType::Int64, false));
         }
 
         // Value is nullable (key might not exist)
@@ -106,13 +138,23 @@ pub fn strings_to_record_batch(data: &[StringData], schema: &StringSchema) -> Re
     let arrow_schema = Arc::new(schema.to_arrow_schema());
     let num_rows = data.len();
 
-    let mut arrays: Vec<ArrayRef> = Vec::with_capacity(2);
+    let mut arrays: Vec<ArrayRef> = Vec::with_capacity(3);
 
     // Build key column if included
     if schema.include_key() {
         let mut builder = StringBuilder::with_capacity(num_rows, num_rows * 32);
         for row in data {
             builder.append_value(&row.key);
+        }
+        arrays.push(Arc::new(builder.finish()));
+    }
+
+    // Build TTL column if included
+    if schema.include_ttl() {
+        let mut builder = Int64Builder::with_capacity(num_rows);
+        for row in data {
+            // TTL: -1 = no expiry, -2 = key doesn't exist, positive = seconds remaining
+            builder.append_value(row.ttl.unwrap_or(-1));
         }
         arrays.push(Arc::new(builder.finish()));
     }
@@ -428,6 +470,15 @@ mod tests {
         StringData {
             key: key.to_string(),
             value: value.map(|s| s.to_string()),
+            ttl: None,
+        }
+    }
+
+    fn make_string_data_with_ttl(key: &str, value: Option<&str>, ttl: i64) -> StringData {
+        StringData {
+            key: key.to_string(),
+            value: value.map(|s| s.to_string()),
+            ttl: Some(ttl),
         }
     }
 
@@ -554,5 +605,42 @@ mod tests {
 
         let batch = strings_to_record_batch(&data, &schema).unwrap();
         assert_eq!(batch.num_rows(), 2);
+    }
+
+    #[test]
+    fn test_string_schema_with_ttl() {
+        let schema = StringSchema::new(DataType::Utf8)
+            .with_ttl(true)
+            .with_ttl_column_name("expires_in");
+
+        assert!(schema.include_ttl());
+        assert_eq!(schema.ttl_column_name(), "expires_in");
+    }
+
+    #[test]
+    fn test_strings_to_record_batch_with_ttl() {
+        let schema = StringSchema::new(DataType::Utf8).with_ttl(true);
+        let data = vec![
+            make_string_data_with_ttl("key:1", Some("hello"), 3600),
+            make_string_data_with_ttl("key:2", Some("world"), -1), // no expiry
+            make_string_data_with_ttl("key:3", Some("test"), 60),
+        ];
+
+        let batch = strings_to_record_batch(&data, &schema).unwrap();
+        assert_eq!(batch.num_rows(), 3);
+        assert_eq!(batch.num_columns(), 3); // _key, _ttl, value
+        assert_eq!(batch.schema().field(1).name(), "_ttl");
+    }
+
+    #[test]
+    fn test_strings_to_record_batch_ttl_column_order() {
+        // Verify column order: key, ttl, value
+        let schema = StringSchema::new(DataType::Utf8).with_ttl(true);
+        let data = vec![make_string_data_with_ttl("key:1", Some("hello"), 100)];
+
+        let batch = strings_to_record_batch(&data, &schema).unwrap();
+        assert_eq!(batch.schema().field(0).name(), "_key");
+        assert_eq!(batch.schema().field(1).name(), "_ttl");
+        assert_eq!(batch.schema().field(2).name(), "value");
     }
 }


### PR DESCRIPTION
Closes #88

## Summary
Add support for reading TTL (time-to-live) values when scanning Redis strings, bringing String type feature parity with Hash and JSON types.

## Changes

### Rust Core
- Add `ttl` field to `StringData` struct
- Add `fetch_ttls()` function for pipelined TTL fetching
- Update `fetch_strings()` to accept `include_ttl` parameter
- Add `include_ttl` and `ttl_column_name` fields to `StringSchema`
- Update `strings_to_record_batch()` to build TTL column
- Update `StringBatchIterator` and `ClusterStringBatchIterator`

### Python Bindings
- Add `include_ttl` and `ttl_column_name` parameters to:
  - `scan_strings()`
  - `read_strings()`
  - `StringScanOptions` class

### Tests
- Add 3 new Python tests for string TTL reads:
  - `test_scan_strings_with_ttl`
  - `test_scan_strings_with_ttl_custom_column_name`
  - `test_scan_strings_without_ttl`

## Usage Example

```python
import polars_redis

# Read strings with TTL column
lf = polars_redis.scan_strings(
    "redis://localhost:6379",
    pattern="cache:*",
    include_ttl=True,
)
df = lf.collect()
# DataFrame now has _key, _ttl, value columns

# With custom TTL column name
lf = polars_redis.scan_strings(
    "redis://localhost:6379",
    pattern="cache:*",
    include_ttl=True,
    ttl_column_name="expires_in",
)

# Using options object
opts = polars_redis.StringScanOptions(
    pattern="cache:*",
    include_ttl=True,
)
lf = polars_redis.scan_strings("redis://localhost:6379", options=opts)
```

## Test Results
- 257 Rust tests passing
- 134 Python tests passing (3 new tests added)