### PR TITLE
feat: add write support for Set, List, and Sorted Set types

### DIFF
--- a/python/polars_redis/__init__.py
+++ b/python/polars_redis/__init__.py
@@ -63,7 +63,10 @@ from polars_redis._write import (
     write_hashes,
     write_hashes_detailed,
     write_json,
+    write_lists,
+    write_sets,
     write_strings,
+    write_zsets,
 )
 
 # Re-export from options module
@@ -103,7 +106,10 @@ __all__ = [
     "write_hashes",
     "write_hashes_detailed",
     "write_json",
+    "write_lists",
+    "write_sets",
     "write_strings",
+    "write_zsets",
     "WriteResult",
     # Utilities
     "scan_keys",


### PR DESCRIPTION
Closes #87

## Summary
Add Python API for writing DataFrames to Redis Sets, Lists, and Sorted Sets. The Rust implementation already existed - this PR exposes it to Python.

## New Functions

### `write_sets()`
Write DataFrame rows as Redis set members, grouped by key.

```python
df = pl.DataFrame({
    "_key": ["tags:1", "tags:1", "tags:2"],
    "member": ["python", "redis", "rust"]
})
count = polars_redis.write_sets(df, "redis://localhost:6379")
# Creates: tags:1 = {python, redis}, tags:2 = {rust}
```

### `write_lists()`
Write DataFrame rows as Redis list elements, grouped by key.

```python
df = pl.DataFrame({
    "_key": ["queue:1", "queue:1", "queue:2"],
    "element": ["a", "b", "c"]
})
count = polars_redis.write_lists(df, "redis://localhost:6379")
# Creates: queue:1 = [a, b], queue:2 = [c]

# With ordering via index column
df = pl.DataFrame({
    "_key": ["queue:1", "queue:1", "queue:1"],
    "_index": [2, 0, 1],
    "element": ["c", "a", "b"]
})
count = polars_redis.write_lists(df, "redis://localhost:6379", index_column="_index")
# Creates: queue:1 = [a, b, c] (sorted by index)
```

### `write_zsets()`
Write DataFrame rows as Redis sorted set members with scores.

```python
df = pl.DataFrame({
    "_key": ["leaderboard:1", "leaderboard:1"],
    "member": ["alice", "bob"],
    "score": [1500.0, 1200.0]
})
count = polars_redis.write_zsets(df, "redis://localhost:6379")
# Creates: leaderboard:1 = {alice: 1500, bob: 1200}
```

## Common Options
All three functions support:
- `ttl`: Optional TTL in seconds
- `key_prefix`: Prefix to prepend to keys
- `if_exists`: "replace" (default), "append", or "fail"
- `key_column`: Column containing Redis keys (default: "_key")
- Custom column names for members/elements/scores

## Changes
- `python/polars_redis/_write.py`: Add `write_sets()`, `write_lists()`, `write_zsets()`
- `python/polars_redis/__init__.py`: Export new functions
- `tests/test_integration.py`: Add 12 new tests

## Test Results
- 257 Rust tests passing
- 146 Python tests passing (12 new)