### PR TITLE
feat: add search_json() and aggregate_json() for RediSearch on JSON documents

### DIFF
--- a/python/polars_redis/__init__.py
+++ b/python/polars_redis/__init__.py
@@ -56,7 +56,9 @@ from polars_redis._scan import (
 )
 from polars_redis._search import (
     aggregate_hashes,
+    aggregate_json,
     search_hashes,
+    search_json,
 )
 from polars_redis._write import (
     WriteResult,
@@ -97,7 +99,9 @@ __all__ = [
     "scan_json",
     "scan_strings",
     "search_hashes",
+    "search_json",
     "aggregate_hashes",
+    "aggregate_json",
     # Read functions (eager)
     "read_hashes",
     "read_json",


### PR DESCRIPTION
## Summary

Adds `search_json()` and `aggregate_json()` functions to search and aggregate RedisJSON documents using RediSearch.

## Changes

- Add `search_json()` function to search RedisJSON documents via RediSearch FT.SEARCH
- Add `aggregate_json()` function to aggregate RedisJSON documents via RediSearch FT.AGGREGATE
- Both functions leverage the FT.SEARCH RETURN clause to request specific field names, which returns flat field-value pairs (matching the hash iterator format)
- Add 9 integration tests:
  - 5 tests for `search_json()`: wildcard query, numeric range, tag filter, sorting, combined queries
  - 4 tests for `aggregate_json()`: count all, group by, average by category, sorting

## Technical Details

RediSearch returns different formats for JSON vs hash indexes when using FT.SEARCH:
- Without RETURN: JSON returns the entire document under a `$` key
- With RETURN <fields>: JSON returns flat field-value pairs (same as hashes)

The `search_json()` function always passes schema fields to the RETURN clause, ensuring the response format is compatible with the existing hash iterator.

Closes #86