### PR TITLE
feat: add Python API for Set, List, ZSet, Stream, and TimeSeries types

### DIFF
--- a/python/polars_redis/__init__.py
+++ b/python/polars_redis/__init__.py
@@ -47,12 +47,22 @@ from polars_redis._internal import (
 from polars_redis._read import (
     read_hashes,
     read_json,
+    read_lists,
+    read_sets,
+    read_streams,
     read_strings,
+    read_timeseries,
+    read_zsets,
 )
 from polars_redis._scan import (
     scan_hashes,
     scan_json,
+    scan_lists,
+    scan_sets,
+    scan_streams,
     scan_strings,
+    scan_timeseries,
+    scan_zsets,
 )
 from polars_redis._search import (
     aggregate_hashes,
@@ -75,11 +85,14 @@ from polars_redis._write import (
 from polars_redis.options import (
     HashScanOptions,
     JsonScanOptions,
+    ListScanOptions,
     ScanOptions,
     SearchOptions,
+    SetScanOptions,
     StreamScanOptions,
     StringScanOptions,
     TimeSeriesScanOptions,
+    ZSetScanOptions,
     get_default_batch_size,
     get_default_count_hint,
     get_default_timeout_ms,
@@ -94,10 +107,15 @@ __all__ = [
     "PyHashBatchIterator",
     "PyJsonBatchIterator",
     "PyStringBatchIterator",
-    # Scan functions
+    # Scan functions (lazy)
     "scan_hashes",
     "scan_json",
+    "scan_lists",
+    "scan_sets",
+    "scan_streams",
     "scan_strings",
+    "scan_timeseries",
+    "scan_zsets",
     "search_hashes",
     "search_json",
     "aggregate_hashes",
@@ -105,7 +123,12 @@ __all__ = [
     # Read functions (eager)
     "read_hashes",
     "read_json",
+    "read_lists",
+    "read_sets",
+    "read_streams",
     "read_strings",
+    "read_timeseries",
+    "read_zsets",
     # Write functions
     "write_hashes",
     "write_hashes_detailed",
@@ -127,9 +150,12 @@ __all__ = [
     "ScanOptions",
     "HashScanOptions",
     "JsonScanOptions",
+    "ListScanOptions",
+    "SetScanOptions",
     "StringScanOptions",
     "StreamScanOptions",
     "TimeSeriesScanOptions",
+    "ZSetScanOptions",
     "SearchOptions",
     # Query builder (predicate pushdown)
     "col",

--- a/python/polars_redis/_read.py
+++ b/python/polars_redis/_read.py
@@ -9,7 +9,16 @@ from __future__ import annotations
 
 import polars as pl
 
-from polars_redis._scan import scan_hashes, scan_json, scan_strings
+from polars_redis._scan import (
+    scan_hashes,
+    scan_json,
+    scan_lists,
+    scan_sets,
+    scan_streams,
+    scan_strings,
+    scan_timeseries,
+    scan_zsets,
+)
 
 
 def read_strings(
@@ -177,6 +186,326 @@ def read_json(
         ttl_column_name=ttl_column_name,
         include_row_index=include_row_index,
         row_index_column_name=row_index_column_name,
+        batch_size=batch_size,
+        count_hint=count_hint,
+    ).collect()
+
+
+def read_sets(
+    url: str,
+    pattern: str = "*",
+    *,
+    include_key: bool = True,
+    key_column_name: str = "_key",
+    member_column_name: str = "member",
+    include_row_index: bool = False,
+    row_index_column_name: str = "_index",
+    batch_size: int = 1000,
+    count_hint: int = 100,
+) -> pl.DataFrame:
+    """Read Redis sets matching a pattern and return a DataFrame.
+
+    This is the eager version of scan_sets(). It immediately executes
+    the scan and returns a DataFrame with all results.
+
+    Args:
+        url: Redis connection URL (e.g., "redis://localhost:6379").
+        pattern: Key pattern to match (e.g., "tags:*").
+        include_key: Whether to include the Redis key as a column.
+        key_column_name: Name of the key column (default: "_key").
+        member_column_name: Name of the member column (default: "member").
+        include_row_index: Whether to include the row index as a column.
+        row_index_column_name: Name of the row index column (default: "_index").
+        batch_size: Number of keys to process per batch.
+        count_hint: SCAN COUNT hint for Redis.
+
+    Returns:
+        A Polars DataFrame containing all set members.
+
+    Example:
+        >>> df = read_sets(
+        ...     "redis://localhost:6379",
+        ...     pattern="tags:*"
+        ... )
+        >>> print(df)
+    """
+    return scan_sets(
+        url=url,
+        pattern=pattern,
+        include_key=include_key,
+        key_column_name=key_column_name,
+        member_column_name=member_column_name,
+        include_row_index=include_row_index,
+        row_index_column_name=row_index_column_name,
+        batch_size=batch_size,
+        count_hint=count_hint,
+    ).collect()
+
+
+def read_lists(
+    url: str,
+    pattern: str = "*",
+    *,
+    include_key: bool = True,
+    key_column_name: str = "_key",
+    element_column_name: str = "element",
+    include_position: bool = False,
+    position_column_name: str = "position",
+    include_row_index: bool = False,
+    row_index_column_name: str = "_index",
+    batch_size: int = 1000,
+    count_hint: int = 100,
+) -> pl.DataFrame:
+    """Read Redis lists matching a pattern and return a DataFrame.
+
+    This is the eager version of scan_lists(). It immediately executes
+    the scan and returns a DataFrame with all results.
+
+    Args:
+        url: Redis connection URL (e.g., "redis://localhost:6379").
+        pattern: Key pattern to match (e.g., "queue:*").
+        include_key: Whether to include the Redis key as a column.
+        key_column_name: Name of the key column (default: "_key").
+        element_column_name: Name of the element column (default: "element").
+        include_position: Whether to include the position index.
+        position_column_name: Name of the position column (default: "position").
+        include_row_index: Whether to include the row index as a column.
+        row_index_column_name: Name of the row index column (default: "_index").
+        batch_size: Number of keys to process per batch.
+        count_hint: SCAN COUNT hint for Redis.
+
+    Returns:
+        A Polars DataFrame containing all list elements.
+
+    Example:
+        >>> df = read_lists(
+        ...     "redis://localhost:6379",
+        ...     pattern="queue:*",
+        ...     include_position=True
+        ... )
+        >>> print(df)
+    """
+    return scan_lists(
+        url=url,
+        pattern=pattern,
+        include_key=include_key,
+        key_column_name=key_column_name,
+        element_column_name=element_column_name,
+        include_position=include_position,
+        position_column_name=position_column_name,
+        include_row_index=include_row_index,
+        row_index_column_name=row_index_column_name,
+        batch_size=batch_size,
+        count_hint=count_hint,
+    ).collect()
+
+
+def read_zsets(
+    url: str,
+    pattern: str = "*",
+    *,
+    include_key: bool = True,
+    key_column_name: str = "_key",
+    member_column_name: str = "member",
+    score_column_name: str = "score",
+    include_rank: bool = False,
+    rank_column_name: str = "rank",
+    include_row_index: bool = False,
+    row_index_column_name: str = "_index",
+    batch_size: int = 1000,
+    count_hint: int = 100,
+) -> pl.DataFrame:
+    """Read Redis sorted sets matching a pattern and return a DataFrame.
+
+    This is the eager version of scan_zsets(). It immediately executes
+    the scan and returns a DataFrame with all results.
+
+    Args:
+        url: Redis connection URL (e.g., "redis://localhost:6379").
+        pattern: Key pattern to match (e.g., "leaderboard:*").
+        include_key: Whether to include the Redis key as a column.
+        key_column_name: Name of the key column (default: "_key").
+        member_column_name: Name of the member column (default: "member").
+        score_column_name: Name of the score column (default: "score").
+        include_rank: Whether to include the rank index.
+        rank_column_name: Name of the rank column (default: "rank").
+        include_row_index: Whether to include the row index as a column.
+        row_index_column_name: Name of the row index column (default: "_index").
+        batch_size: Number of keys to process per batch.
+        count_hint: SCAN COUNT hint for Redis.
+
+    Returns:
+        A Polars DataFrame containing all sorted set members with scores.
+
+    Example:
+        >>> df = read_zsets(
+        ...     "redis://localhost:6379",
+        ...     pattern="leaderboard:*",
+        ...     include_rank=True
+        ... )
+        >>> print(df)
+    """
+    return scan_zsets(
+        url=url,
+        pattern=pattern,
+        include_key=include_key,
+        key_column_name=key_column_name,
+        member_column_name=member_column_name,
+        score_column_name=score_column_name,
+        include_rank=include_rank,
+        rank_column_name=rank_column_name,
+        include_row_index=include_row_index,
+        row_index_column_name=row_index_column_name,
+        batch_size=batch_size,
+        count_hint=count_hint,
+    ).collect()
+
+
+def read_streams(
+    url: str,
+    pattern: str = "*",
+    *,
+    schema: dict | None = None,
+    include_key: bool = True,
+    key_column_name: str = "_key",
+    include_id: bool = True,
+    id_column_name: str = "_id",
+    include_timestamp: bool = True,
+    timestamp_column_name: str = "_ts",
+    include_sequence: bool = False,
+    sequence_column_name: str = "_seq",
+    include_row_index: bool = False,
+    row_index_column_name: str = "_index",
+    start_id: str = "-",
+    end_id: str = "+",
+    count_per_stream: int | None = None,
+    batch_size: int = 1000,
+    count_hint: int = 100,
+) -> pl.DataFrame:
+    """Read Redis streams matching a pattern and return a DataFrame.
+
+    This is the eager version of scan_streams(). It immediately executes
+    the scan and returns a DataFrame with all results.
+
+    Args:
+        url: Redis connection URL (e.g., "redis://localhost:6379").
+        pattern: Key pattern to match (e.g., "events:*").
+        schema: Dictionary mapping field names to Polars dtypes for stream fields.
+        include_key: Whether to include the Redis key as a column.
+        key_column_name: Name of the key column (default: "_key").
+        include_id: Whether to include the entry ID as a column.
+        id_column_name: Name of the entry ID column (default: "_id").
+        include_timestamp: Whether to include the timestamp as a column.
+        timestamp_column_name: Name of the timestamp column (default: "_ts").
+        include_sequence: Whether to include the sequence number.
+        sequence_column_name: Name of the sequence column (default: "_seq").
+        include_row_index: Whether to include the row index as a column.
+        row_index_column_name: Name of the row index column (default: "_index").
+        start_id: Start ID for XRANGE (default: "-" for oldest).
+        end_id: End ID for XRANGE (default: "+" for newest).
+        count_per_stream: Maximum entries per stream (optional).
+        batch_size: Number of keys to process per batch.
+        count_hint: SCAN COUNT hint for Redis.
+
+    Returns:
+        A Polars DataFrame containing all stream entries.
+
+    Example:
+        >>> df = read_streams(
+        ...     "redis://localhost:6379",
+        ...     pattern="events:*",
+        ...     schema={"event_type": pl.Utf8, "data": pl.Utf8}
+        ... )
+        >>> print(df)
+    """
+    return scan_streams(
+        url=url,
+        pattern=pattern,
+        schema=schema,
+        include_key=include_key,
+        key_column_name=key_column_name,
+        include_id=include_id,
+        id_column_name=id_column_name,
+        include_timestamp=include_timestamp,
+        timestamp_column_name=timestamp_column_name,
+        include_sequence=include_sequence,
+        sequence_column_name=sequence_column_name,
+        include_row_index=include_row_index,
+        row_index_column_name=row_index_column_name,
+        start_id=start_id,
+        end_id=end_id,
+        count_per_stream=count_per_stream,
+        batch_size=batch_size,
+        count_hint=count_hint,
+    ).collect()
+
+
+def read_timeseries(
+    url: str,
+    pattern: str = "*",
+    *,
+    include_key: bool = True,
+    key_column_name: str = "_key",
+    timestamp_column_name: str = "_ts",
+    value_column_name: str = "value",
+    include_row_index: bool = False,
+    row_index_column_name: str = "_index",
+    start: str = "-",
+    end: str = "+",
+    count_per_series: int | None = None,
+    aggregation: str | None = None,
+    bucket_size_ms: int | None = None,
+    batch_size: int = 1000,
+    count_hint: int = 100,
+) -> pl.DataFrame:
+    """Read Redis time series matching a pattern and return a DataFrame.
+
+    This is the eager version of scan_timeseries(). It immediately executes
+    the scan and returns a DataFrame with all results.
+
+    Args:
+        url: Redis connection URL (e.g., "redis://localhost:6379").
+        pattern: Key pattern to match (e.g., "sensor:*").
+        include_key: Whether to include the Redis key as a column.
+        key_column_name: Name of the key column (default: "_key").
+        timestamp_column_name: Name of the timestamp column (default: "_ts").
+        value_column_name: Name of the value column (default: "value").
+        include_row_index: Whether to include the row index as a column.
+        row_index_column_name: Name of the row index column (default: "_index").
+        start: Start timestamp for TS.RANGE (default: "-" for oldest).
+        end: End timestamp for TS.RANGE (default: "+" for newest).
+        count_per_series: Maximum samples per time series (optional).
+        aggregation: Aggregation type (avg, sum, min, max, etc.).
+        bucket_size_ms: Bucket size in milliseconds for aggregation.
+        batch_size: Number of keys to process per batch.
+        count_hint: SCAN COUNT hint for Redis.
+
+    Returns:
+        A Polars DataFrame containing all time series samples.
+
+    Example:
+        >>> df = read_timeseries(
+        ...     "redis://localhost:6379",
+        ...     pattern="sensor:*",
+        ...     aggregation="avg",
+        ...     bucket_size_ms=60000
+        ... )
+        >>> print(df)
+    """
+    return scan_timeseries(
+        url=url,
+        pattern=pattern,
+        include_key=include_key,
+        key_column_name=key_column_name,
+        timestamp_column_name=timestamp_column_name,
+        value_column_name=value_column_name,
+        include_row_index=include_row_index,
+        row_index_column_name=row_index_column_name,
+        start=start,
+        end=end,
+        count_per_series=count_per_series,
+        aggregation=aggregation,
+        bucket_size_ms=bucket_size_ms,
         batch_size=batch_size,
         count_hint=count_hint,
     ).collect()

--- a/python/polars_redis/_scan.py
+++ b/python/polars_redis/_scan.py
@@ -15,10 +15,24 @@ from polars.io.plugins import register_io_source
 from polars_redis._internal import (
     PyHashBatchIterator,
     PyJsonBatchIterator,
+    PyListBatchIterator,
+    PySetBatchIterator,
+    PyStreamBatchIterator,
     PyStringBatchIterator,
+    PyTimeSeriesBatchIterator,
+    PyZSetBatchIterator,
 )
 from polars_redis._utils import _polars_dtype_to_internal
-from polars_redis.options import HashScanOptions, JsonScanOptions, StringScanOptions
+from polars_redis.options import (
+    HashScanOptions,
+    JsonScanOptions,
+    ListScanOptions,
+    SetScanOptions,
+    StreamScanOptions,
+    StringScanOptions,
+    TimeSeriesScanOptions,
+    ZSetScanOptions,
+)
 
 if TYPE_CHECKING:
     from polars import DataFrame, Expr
@@ -341,6 +355,637 @@ def scan_json(
 
     return register_io_source(
         io_source=_json_source,
+        schema=polars_schema,
+    )
+
+
+def scan_sets(
+    url: str,
+    pattern: str = "*",
+    *,
+    options: SetScanOptions | None = None,
+    include_key: bool = True,
+    key_column_name: str = "_key",
+    member_column_name: str = "member",
+    include_row_index: bool = False,
+    row_index_column_name: str = "_index",
+    batch_size: int = 1000,
+    count_hint: int = 100,
+) -> pl.LazyFrame:
+    """Scan Redis sets matching a pattern and return a LazyFrame.
+
+    Each set member becomes a row in the resulting DataFrame.
+
+    Args:
+        url: Redis connection URL (e.g., "redis://localhost:6379").
+        pattern: Key pattern to match (e.g., "tags:*").
+        options: SetScanOptions object for configuration. If provided,
+            individual keyword arguments are ignored.
+        include_key: Whether to include the Redis key as a column.
+        key_column_name: Name of the key column (default: "_key").
+        member_column_name: Name of the member column (default: "member").
+        include_row_index: Whether to include the row index as a column.
+        row_index_column_name: Name of the row index column (default: "_index").
+        batch_size: Number of keys to process per batch.
+        count_hint: SCAN COUNT hint for Redis.
+
+    Returns:
+        A Polars LazyFrame that will scan Redis when collected.
+
+    Example:
+        >>> lf = scan_sets(
+        ...     "redis://localhost:6379",
+        ...     pattern="tags:*",
+        ...     member_column_name="tag",
+        ... )
+        >>> df = lf.collect()
+    """
+    # If options object provided, use its values
+    if options is not None:
+        pattern = options.pattern
+        include_key = options.include_key
+        key_column_name = options.key_column_name
+        member_column_name = options.member_column_name
+        include_row_index = options.include_row_index
+        row_index_column_name = options.row_index_column_name
+        batch_size = options.batch_size
+        count_hint = options.count_hint
+
+    # Build the full Polars schema
+    polars_schema: SchemaDict = {}
+    if include_row_index:
+        polars_schema[row_index_column_name] = pl.UInt64
+    if include_key:
+        polars_schema[key_column_name] = pl.Utf8
+    polars_schema[member_column_name] = pl.Utf8
+
+    def _set_source(
+        with_columns: list[str] | None,
+        predicate: Expr | None,
+        n_rows: int | None,
+        batch_size_hint: int | None,
+    ) -> Iterator[DataFrame]:
+        """Generator that yields DataFrames from Redis sets."""
+        effective_batch_size = batch_size_hint if batch_size_hint is not None else batch_size
+
+        iterator = PySetBatchIterator(
+            url=url,
+            pattern=pattern,
+            batch_size=effective_batch_size,
+            count_hint=count_hint,
+            include_key=include_key,
+            key_column_name=key_column_name,
+            member_column_name=member_column_name,
+            include_row_index=include_row_index,
+            row_index_column_name=row_index_column_name,
+            max_rows=n_rows,
+        )
+
+        while not iterator.is_done():
+            ipc_bytes = iterator.next_batch_ipc()
+            if ipc_bytes is None:
+                break
+
+            df = pl.read_ipc(ipc_bytes)
+
+            if predicate is not None:
+                df = df.filter(predicate)
+
+            if with_columns is not None:
+                available = [c for c in with_columns if c in df.columns]
+                if available:
+                    df = df.select(available)
+
+            if len(df) > 0:
+                yield df
+
+    return register_io_source(
+        io_source=_set_source,
+        schema=polars_schema,
+    )
+
+
+def scan_lists(
+    url: str,
+    pattern: str = "*",
+    *,
+    options: ListScanOptions | None = None,
+    include_key: bool = True,
+    key_column_name: str = "_key",
+    element_column_name: str = "element",
+    include_position: bool = False,
+    position_column_name: str = "position",
+    include_row_index: bool = False,
+    row_index_column_name: str = "_index",
+    batch_size: int = 1000,
+    count_hint: int = 100,
+) -> pl.LazyFrame:
+    """Scan Redis lists matching a pattern and return a LazyFrame.
+
+    Each list element becomes a row in the resulting DataFrame.
+
+    Args:
+        url: Redis connection URL (e.g., "redis://localhost:6379").
+        pattern: Key pattern to match (e.g., "queue:*").
+        options: ListScanOptions object for configuration. If provided,
+            individual keyword arguments are ignored.
+        include_key: Whether to include the Redis key as a column.
+        key_column_name: Name of the key column (default: "_key").
+        element_column_name: Name of the element column (default: "element").
+        include_position: Whether to include the position index.
+        position_column_name: Name of the position column (default: "position").
+        include_row_index: Whether to include the row index as a column.
+        row_index_column_name: Name of the row index column (default: "_index").
+        batch_size: Number of keys to process per batch.
+        count_hint: SCAN COUNT hint for Redis.
+
+    Returns:
+        A Polars LazyFrame that will scan Redis when collected.
+
+    Example:
+        >>> lf = scan_lists(
+        ...     "redis://localhost:6379",
+        ...     pattern="queue:*",
+        ...     include_position=True,
+        ... )
+        >>> df = lf.collect()
+    """
+    # If options object provided, use its values
+    if options is not None:
+        pattern = options.pattern
+        include_key = options.include_key
+        key_column_name = options.key_column_name
+        element_column_name = options.element_column_name
+        include_position = options.include_position
+        position_column_name = options.position_column_name
+        include_row_index = options.include_row_index
+        row_index_column_name = options.row_index_column_name
+        batch_size = options.batch_size
+        count_hint = options.count_hint
+
+    # Build the full Polars schema
+    polars_schema: SchemaDict = {}
+    if include_row_index:
+        polars_schema[row_index_column_name] = pl.UInt64
+    if include_key:
+        polars_schema[key_column_name] = pl.Utf8
+    if include_position:
+        polars_schema[position_column_name] = pl.UInt64
+    polars_schema[element_column_name] = pl.Utf8
+
+    def _list_source(
+        with_columns: list[str] | None,
+        predicate: Expr | None,
+        n_rows: int | None,
+        batch_size_hint: int | None,
+    ) -> Iterator[DataFrame]:
+        """Generator that yields DataFrames from Redis lists."""
+        effective_batch_size = batch_size_hint if batch_size_hint is not None else batch_size
+
+        iterator = PyListBatchIterator(
+            url=url,
+            pattern=pattern,
+            batch_size=effective_batch_size,
+            count_hint=count_hint,
+            include_key=include_key,
+            key_column_name=key_column_name,
+            element_column_name=element_column_name,
+            include_position=include_position,
+            position_column_name=position_column_name,
+            include_row_index=include_row_index,
+            row_index_column_name=row_index_column_name,
+            max_rows=n_rows,
+        )
+
+        while not iterator.is_done():
+            ipc_bytes = iterator.next_batch_ipc()
+            if ipc_bytes is None:
+                break
+
+            df = pl.read_ipc(ipc_bytes)
+
+            if predicate is not None:
+                df = df.filter(predicate)
+
+            if with_columns is not None:
+                available = [c for c in with_columns if c in df.columns]
+                if available:
+                    df = df.select(available)
+
+            if len(df) > 0:
+                yield df
+
+    return register_io_source(
+        io_source=_list_source,
+        schema=polars_schema,
+    )
+
+
+def scan_zsets(
+    url: str,
+    pattern: str = "*",
+    *,
+    options: ZSetScanOptions | None = None,
+    include_key: bool = True,
+    key_column_name: str = "_key",
+    member_column_name: str = "member",
+    score_column_name: str = "score",
+    include_rank: bool = False,
+    rank_column_name: str = "rank",
+    include_row_index: bool = False,
+    row_index_column_name: str = "_index",
+    batch_size: int = 1000,
+    count_hint: int = 100,
+) -> pl.LazyFrame:
+    """Scan Redis sorted sets matching a pattern and return a LazyFrame.
+
+    Each member-score pair becomes a row in the resulting DataFrame.
+
+    Args:
+        url: Redis connection URL (e.g., "redis://localhost:6379").
+        pattern: Key pattern to match (e.g., "leaderboard:*").
+        options: ZSetScanOptions object for configuration. If provided,
+            individual keyword arguments are ignored.
+        include_key: Whether to include the Redis key as a column.
+        key_column_name: Name of the key column (default: "_key").
+        member_column_name: Name of the member column (default: "member").
+        score_column_name: Name of the score column (default: "score").
+        include_rank: Whether to include the rank index.
+        rank_column_name: Name of the rank column (default: "rank").
+        include_row_index: Whether to include the row index as a column.
+        row_index_column_name: Name of the row index column (default: "_index").
+        batch_size: Number of keys to process per batch.
+        count_hint: SCAN COUNT hint for Redis.
+
+    Returns:
+        A Polars LazyFrame that will scan Redis when collected.
+
+    Example:
+        >>> lf = scan_zsets(
+        ...     "redis://localhost:6379",
+        ...     pattern="leaderboard:*",
+        ...     include_rank=True,
+        ... )
+        >>> df = lf.collect()
+    """
+    # If options object provided, use its values
+    if options is not None:
+        pattern = options.pattern
+        include_key = options.include_key
+        key_column_name = options.key_column_name
+        member_column_name = options.member_column_name
+        score_column_name = options.score_column_name
+        include_rank = options.include_rank
+        rank_column_name = options.rank_column_name
+        include_row_index = options.include_row_index
+        row_index_column_name = options.row_index_column_name
+        batch_size = options.batch_size
+        count_hint = options.count_hint
+
+    # Build the full Polars schema
+    polars_schema: SchemaDict = {}
+    if include_row_index:
+        polars_schema[row_index_column_name] = pl.UInt64
+    if include_key:
+        polars_schema[key_column_name] = pl.Utf8
+    if include_rank:
+        polars_schema[rank_column_name] = pl.UInt64
+    polars_schema[member_column_name] = pl.Utf8
+    polars_schema[score_column_name] = pl.Float64
+
+    def _zset_source(
+        with_columns: list[str] | None,
+        predicate: Expr | None,
+        n_rows: int | None,
+        batch_size_hint: int | None,
+    ) -> Iterator[DataFrame]:
+        """Generator that yields DataFrames from Redis sorted sets."""
+        effective_batch_size = batch_size_hint if batch_size_hint is not None else batch_size
+
+        iterator = PyZSetBatchIterator(
+            url=url,
+            pattern=pattern,
+            batch_size=effective_batch_size,
+            count_hint=count_hint,
+            include_key=include_key,
+            key_column_name=key_column_name,
+            member_column_name=member_column_name,
+            score_column_name=score_column_name,
+            include_rank=include_rank,
+            rank_column_name=rank_column_name,
+            include_row_index=include_row_index,
+            row_index_column_name=row_index_column_name,
+            max_rows=n_rows,
+        )
+
+        while not iterator.is_done():
+            ipc_bytes = iterator.next_batch_ipc()
+            if ipc_bytes is None:
+                break
+
+            df = pl.read_ipc(ipc_bytes)
+
+            if predicate is not None:
+                df = df.filter(predicate)
+
+            if with_columns is not None:
+                available = [c for c in with_columns if c in df.columns]
+                if available:
+                    df = df.select(available)
+
+            if len(df) > 0:
+                yield df
+
+    return register_io_source(
+        io_source=_zset_source,
+        schema=polars_schema,
+    )
+
+
+def scan_streams(
+    url: str,
+    pattern: str = "*",
+    *,
+    schema: dict | None = None,
+    options: StreamScanOptions | None = None,
+    include_key: bool = True,
+    key_column_name: str = "_key",
+    include_id: bool = True,
+    id_column_name: str = "_id",
+    include_timestamp: bool = True,
+    timestamp_column_name: str = "_ts",
+    include_sequence: bool = False,
+    sequence_column_name: str = "_seq",
+    include_row_index: bool = False,
+    row_index_column_name: str = "_index",
+    start_id: str = "-",
+    end_id: str = "+",
+    count_per_stream: int | None = None,
+    batch_size: int = 1000,
+    count_hint: int = 100,
+) -> pl.LazyFrame:
+    """Scan Redis streams matching a pattern and return a LazyFrame.
+
+    Each stream entry becomes a row in the resulting DataFrame.
+
+    Args:
+        url: Redis connection URL (e.g., "redis://localhost:6379").
+        pattern: Key pattern to match (e.g., "events:*").
+        schema: Dictionary mapping field names to Polars dtypes for stream fields.
+        options: StreamScanOptions object for configuration. If provided,
+            individual keyword arguments are ignored.
+        include_key: Whether to include the Redis key as a column.
+        key_column_name: Name of the key column (default: "_key").
+        include_id: Whether to include the entry ID as a column.
+        id_column_name: Name of the entry ID column (default: "_id").
+        include_timestamp: Whether to include the timestamp as a column.
+        timestamp_column_name: Name of the timestamp column (default: "_ts").
+        include_sequence: Whether to include the sequence number.
+        sequence_column_name: Name of the sequence column (default: "_seq").
+        include_row_index: Whether to include the row index as a column.
+        row_index_column_name: Name of the row index column (default: "_index").
+        start_id: Start ID for XRANGE (default: "-" for oldest).
+        end_id: End ID for XRANGE (default: "+" for newest).
+        count_per_stream: Maximum entries per stream (optional).
+        batch_size: Number of keys to process per batch.
+        count_hint: SCAN COUNT hint for Redis.
+
+    Returns:
+        A Polars LazyFrame that will scan Redis when collected.
+
+    Example:
+        >>> lf = scan_streams(
+        ...     "redis://localhost:6379",
+        ...     pattern="events:*",
+        ...     schema={"event_type": pl.Utf8, "data": pl.Utf8},
+        ... )
+        >>> df = lf.collect()
+    """
+    # If options object provided, use its values
+    fields: list[str] = []
+    if options is not None:
+        pattern = options.pattern
+        include_key = options.include_key
+        key_column_name = options.key_column_name
+        include_id = options.include_id
+        include_timestamp = options.include_timestamp
+        include_sequence = options.include_sequence
+        include_row_index = options.include_row_index
+        row_index_column_name = options.row_index_column_name
+        start_id = options.start_id
+        end_id = options.end_id
+        count_per_stream = options.count_per_stream
+        batch_size = options.batch_size
+        count_hint = options.count_hint
+        if options.fields:
+            fields = options.fields
+
+    # Get field names from schema if provided
+    if schema:
+        fields = list(schema.keys())
+
+    # Build the full Polars schema
+    polars_schema: SchemaDict = {}
+    if include_row_index:
+        polars_schema[row_index_column_name] = pl.UInt64
+    if include_key:
+        polars_schema[key_column_name] = pl.Utf8
+    if include_id:
+        polars_schema[id_column_name] = pl.Utf8
+    if include_timestamp:
+        polars_schema[timestamp_column_name] = pl.UInt64
+    if include_sequence:
+        polars_schema[sequence_column_name] = pl.UInt64
+    # Add field columns from schema
+    if schema:
+        for name, dtype in schema.items():
+            polars_schema[name] = dtype
+
+    def _stream_source(
+        with_columns: list[str] | None,
+        predicate: Expr | None,
+        n_rows: int | None,
+        batch_size_hint: int | None,
+    ) -> Iterator[DataFrame]:
+        """Generator that yields DataFrames from Redis streams."""
+        effective_batch_size = batch_size_hint if batch_size_hint is not None else batch_size
+
+        iterator = PyStreamBatchIterator(
+            url=url,
+            pattern=pattern,
+            fields=fields,
+            batch_size=effective_batch_size,
+            count_hint=count_hint,
+            start_id=start_id,
+            end_id=end_id,
+            count_per_stream=count_per_stream,
+            include_key=include_key,
+            key_column_name=key_column_name,
+            include_id=include_id,
+            id_column_name=id_column_name,
+            include_timestamp=include_timestamp,
+            timestamp_column_name=timestamp_column_name,
+            include_sequence=include_sequence,
+            sequence_column_name=sequence_column_name,
+            include_row_index=include_row_index,
+            row_index_column_name=row_index_column_name,
+            max_rows=n_rows,
+        )
+
+        while not iterator.is_done():
+            ipc_bytes = iterator.next_batch_ipc()
+            if ipc_bytes is None:
+                break
+
+            df = pl.read_ipc(ipc_bytes)
+
+            if predicate is not None:
+                df = df.filter(predicate)
+
+            if with_columns is not None:
+                available = [c for c in with_columns if c in df.columns]
+                if available:
+                    df = df.select(available)
+
+            if len(df) > 0:
+                yield df
+
+    return register_io_source(
+        io_source=_stream_source,
+        schema=polars_schema,
+    )
+
+
+def scan_timeseries(
+    url: str,
+    pattern: str = "*",
+    *,
+    options: TimeSeriesScanOptions | None = None,
+    include_key: bool = True,
+    key_column_name: str = "_key",
+    timestamp_column_name: str = "_ts",
+    value_column_name: str = "value",
+    include_row_index: bool = False,
+    row_index_column_name: str = "_index",
+    start: str = "-",
+    end: str = "+",
+    count_per_series: int | None = None,
+    aggregation: str | None = None,
+    bucket_size_ms: int | None = None,
+    batch_size: int = 1000,
+    count_hint: int = 100,
+) -> pl.LazyFrame:
+    """Scan Redis time series matching a pattern and return a LazyFrame.
+
+    Each time series sample becomes a row in the resulting DataFrame.
+
+    Args:
+        url: Redis connection URL (e.g., "redis://localhost:6379").
+        pattern: Key pattern to match (e.g., "sensor:*").
+        options: TimeSeriesScanOptions object for configuration. If provided,
+            individual keyword arguments are ignored.
+        include_key: Whether to include the Redis key as a column.
+        key_column_name: Name of the key column (default: "_key").
+        timestamp_column_name: Name of the timestamp column (default: "_ts").
+        value_column_name: Name of the value column (default: "value").
+        include_row_index: Whether to include the row index as a column.
+        row_index_column_name: Name of the row index column (default: "_index").
+        start: Start timestamp for TS.RANGE (default: "-" for oldest).
+        end: End timestamp for TS.RANGE (default: "+" for newest).
+        count_per_series: Maximum samples per time series (optional).
+        aggregation: Aggregation type (avg, sum, min, max, etc.).
+        bucket_size_ms: Bucket size in milliseconds for aggregation.
+        batch_size: Number of keys to process per batch.
+        count_hint: SCAN COUNT hint for Redis.
+
+    Returns:
+        A Polars LazyFrame that will scan Redis when collected.
+
+    Example:
+        >>> lf = scan_timeseries(
+        ...     "redis://localhost:6379",
+        ...     pattern="sensor:*",
+        ...     aggregation="avg",
+        ...     bucket_size_ms=60000,
+        ... )
+        >>> df = lf.collect()
+    """
+    # If options object provided, use its values
+    if options is not None:
+        pattern = options.pattern
+        include_key = options.include_key
+        key_column_name = options.key_column_name
+        timestamp_column_name = options.timestamp_column_name
+        value_column_name = options.value_column_name
+        include_row_index = options.include_row_index
+        row_index_column_name = options.row_index_column_name
+        start = options.start
+        end = options.end
+        count_per_series = options.count_per_series
+        aggregation = options.aggregation
+        bucket_size_ms = options.bucket_size_ms
+        batch_size = options.batch_size
+        count_hint = options.count_hint
+
+    # Build the full Polars schema
+    polars_schema: SchemaDict = {}
+    if include_row_index:
+        polars_schema[row_index_column_name] = pl.UInt64
+    if include_key:
+        polars_schema[key_column_name] = pl.Utf8
+    polars_schema[timestamp_column_name] = pl.Int64
+    polars_schema[value_column_name] = pl.Float64
+
+    def _timeseries_source(
+        with_columns: list[str] | None,
+        predicate: Expr | None,
+        n_rows: int | None,
+        batch_size_hint: int | None,
+    ) -> Iterator[DataFrame]:
+        """Generator that yields DataFrames from Redis time series."""
+        effective_batch_size = batch_size_hint if batch_size_hint is not None else batch_size
+
+        iterator = PyTimeSeriesBatchIterator(
+            url=url,
+            pattern=pattern,
+            batch_size=effective_batch_size,
+            count_hint=count_hint,
+            start=start,
+            end=end,
+            count_per_series=count_per_series,
+            aggregation=aggregation,
+            bucket_size_ms=bucket_size_ms,
+            include_key=include_key,
+            key_column_name=key_column_name,
+            include_timestamp=True,
+            timestamp_column_name=timestamp_column_name,
+            value_column_name=value_column_name,
+            include_row_index=include_row_index,
+            row_index_column_name=row_index_column_name,
+            label_columns=[],
+            max_rows=n_rows,
+        )
+
+        while not iterator.is_done():
+            ipc_bytes = iterator.next_batch_ipc()
+            if ipc_bytes is None:
+                break
+
+            df = pl.read_ipc(ipc_bytes)
+
+            if predicate is not None:
+                df = df.filter(predicate)
+
+            if with_columns is not None:
+                available = [c for c in with_columns if c in df.columns]
+                if available:
+                    df = df.select(available)
+
+            if len(df) > 0:
+                yield df
+
+    return register_io_source(
+        io_source=_timeseries_source,
         schema=polars_schema,
     )
 

--- a/python/polars_redis/options.py
+++ b/python/polars_redis/options.py
@@ -27,6 +27,9 @@ __all__ = [
     "HashScanOptions",
     "JsonScanOptions",
     "StringScanOptions",
+    "SetScanOptions",
+    "ListScanOptions",
+    "ZSetScanOptions",
     "StreamScanOptions",
     "TimeSeriesScanOptions",
     "SearchOptions",
@@ -363,6 +366,253 @@ class StringScanOptions:
             self.row_index_column_name = name
         if offset is not None:
             self.row_index_offset = offset
+        return self
+
+
+@dataclass
+class SetScanOptions:
+    """Options for scanning Redis sets.
+
+    Example:
+        >>> opts = SetScanOptions(
+        ...     pattern="tags:*",
+        ...     member_column_name="tag",
+        ... )
+
+    Attributes:
+        pattern: Key pattern to match (e.g., "tags:*").
+        batch_size: Number of keys to process per batch.
+        count_hint: SCAN COUNT hint for Redis.
+        n_rows: Maximum total rows to return (None for unlimited).
+        include_key: Whether to include the Redis key as a column.
+        key_column_name: Name of the key column.
+        member_column_name: Name of the member column.
+        include_row_index: Whether to include the row index as a column.
+        row_index_column_name: Name of the row index column.
+    """
+
+    pattern: str = "*"
+    batch_size: int = field(default_factory=get_default_batch_size)
+    count_hint: int = field(default_factory=get_default_count_hint)
+    n_rows: int | None = None
+    include_key: bool = True
+    key_column_name: str = "_key"
+    member_column_name: str = "member"
+    include_row_index: bool = False
+    row_index_column_name: str = "_index"
+
+    def with_pattern(self, pattern: str) -> SetScanOptions:
+        """Set the key pattern."""
+        self.pattern = pattern
+        return self
+
+    def with_batch_size(self, size: int) -> SetScanOptions:
+        """Set the batch size."""
+        self.batch_size = size
+        return self
+
+    def with_count_hint(self, count: int) -> SetScanOptions:
+        """Set the COUNT hint for SCAN."""
+        self.count_hint = count
+        return self
+
+    def with_n_rows(self, n: int) -> SetScanOptions:
+        """Set the maximum number of rows to return."""
+        self.n_rows = n
+        return self
+
+    def with_key(self, include: bool = True, name: str | None = None) -> SetScanOptions:
+        """Configure the key column."""
+        self.include_key = include
+        if name is not None:
+            self.key_column_name = name
+        return self
+
+    def with_member_column_name(self, name: str) -> SetScanOptions:
+        """Set the member column name."""
+        self.member_column_name = name
+        return self
+
+    def with_row_index(self, include: bool = True, name: str | None = None) -> SetScanOptions:
+        """Configure the row index column."""
+        self.include_row_index = include
+        if name is not None:
+            self.row_index_column_name = name
+        return self
+
+
+@dataclass
+class ListScanOptions:
+    """Options for scanning Redis lists.
+
+    Example:
+        >>> opts = ListScanOptions(
+        ...     pattern="queue:*",
+        ...     element_column_name="item",
+        ...     include_position=True,
+        ... )
+
+    Attributes:
+        pattern: Key pattern to match (e.g., "queue:*").
+        batch_size: Number of keys to process per batch.
+        count_hint: SCAN COUNT hint for Redis.
+        n_rows: Maximum total rows to return (None for unlimited).
+        include_key: Whether to include the Redis key as a column.
+        key_column_name: Name of the key column.
+        element_column_name: Name of the element column.
+        include_position: Whether to include the position index.
+        position_column_name: Name of the position column.
+        include_row_index: Whether to include the row index as a column.
+        row_index_column_name: Name of the row index column.
+    """
+
+    pattern: str = "*"
+    batch_size: int = field(default_factory=get_default_batch_size)
+    count_hint: int = field(default_factory=get_default_count_hint)
+    n_rows: int | None = None
+    include_key: bool = True
+    key_column_name: str = "_key"
+    element_column_name: str = "element"
+    include_position: bool = False
+    position_column_name: str = "position"
+    include_row_index: bool = False
+    row_index_column_name: str = "_index"
+
+    def with_pattern(self, pattern: str) -> ListScanOptions:
+        """Set the key pattern."""
+        self.pattern = pattern
+        return self
+
+    def with_batch_size(self, size: int) -> ListScanOptions:
+        """Set the batch size."""
+        self.batch_size = size
+        return self
+
+    def with_count_hint(self, count: int) -> ListScanOptions:
+        """Set the COUNT hint for SCAN."""
+        self.count_hint = count
+        return self
+
+    def with_n_rows(self, n: int) -> ListScanOptions:
+        """Set the maximum number of rows to return."""
+        self.n_rows = n
+        return self
+
+    def with_key(self, include: bool = True, name: str | None = None) -> ListScanOptions:
+        """Configure the key column."""
+        self.include_key = include
+        if name is not None:
+            self.key_column_name = name
+        return self
+
+    def with_element_column_name(self, name: str) -> ListScanOptions:
+        """Set the element column name."""
+        self.element_column_name = name
+        return self
+
+    def with_position(self, include: bool = True, name: str | None = None) -> ListScanOptions:
+        """Configure the position column."""
+        self.include_position = include
+        if name is not None:
+            self.position_column_name = name
+        return self
+
+    def with_row_index(self, include: bool = True, name: str | None = None) -> ListScanOptions:
+        """Configure the row index column."""
+        self.include_row_index = include
+        if name is not None:
+            self.row_index_column_name = name
+        return self
+
+
+@dataclass
+class ZSetScanOptions:
+    """Options for scanning Redis sorted sets.
+
+    Example:
+        >>> opts = ZSetScanOptions(
+        ...     pattern="leaderboard:*",
+        ...     member_column_name="player",
+        ...     include_rank=True,
+        ... )
+
+    Attributes:
+        pattern: Key pattern to match (e.g., "leaderboard:*").
+        batch_size: Number of keys to process per batch.
+        count_hint: SCAN COUNT hint for Redis.
+        n_rows: Maximum total rows to return (None for unlimited).
+        include_key: Whether to include the Redis key as a column.
+        key_column_name: Name of the key column.
+        member_column_name: Name of the member column.
+        score_column_name: Name of the score column.
+        include_rank: Whether to include the rank index.
+        rank_column_name: Name of the rank column.
+        include_row_index: Whether to include the row index as a column.
+        row_index_column_name: Name of the row index column.
+    """
+
+    pattern: str = "*"
+    batch_size: int = field(default_factory=get_default_batch_size)
+    count_hint: int = field(default_factory=get_default_count_hint)
+    n_rows: int | None = None
+    include_key: bool = True
+    key_column_name: str = "_key"
+    member_column_name: str = "member"
+    score_column_name: str = "score"
+    include_rank: bool = False
+    rank_column_name: str = "rank"
+    include_row_index: bool = False
+    row_index_column_name: str = "_index"
+
+    def with_pattern(self, pattern: str) -> ZSetScanOptions:
+        """Set the key pattern."""
+        self.pattern = pattern
+        return self
+
+    def with_batch_size(self, size: int) -> ZSetScanOptions:
+        """Set the batch size."""
+        self.batch_size = size
+        return self
+
+    def with_count_hint(self, count: int) -> ZSetScanOptions:
+        """Set the COUNT hint for SCAN."""
+        self.count_hint = count
+        return self
+
+    def with_n_rows(self, n: int) -> ZSetScanOptions:
+        """Set the maximum number of rows to return."""
+        self.n_rows = n
+        return self
+
+    def with_key(self, include: bool = True, name: str | None = None) -> ZSetScanOptions:
+        """Configure the key column."""
+        self.include_key = include
+        if name is not None:
+            self.key_column_name = name
+        return self
+
+    def with_member_column_name(self, name: str) -> ZSetScanOptions:
+        """Set the member column name."""
+        self.member_column_name = name
+        return self
+
+    def with_score_column_name(self, name: str) -> ZSetScanOptions:
+        """Set the score column name."""
+        self.score_column_name = name
+        return self
+
+    def with_rank(self, include: bool = True, name: str | None = None) -> ZSetScanOptions:
+        """Configure the rank column."""
+        self.include_rank = include
+        if name is not None:
+            self.rank_column_name = name
+        return self
+
+    def with_row_index(self, include: bool = True, name: str | None = None) -> ZSetScanOptions:
+        """Configure the row index column."""
+        self.include_row_index = include
+        if name is not None:
+            self.row_index_column_name = name
         return self
 
 


### PR DESCRIPTION
This PR adds Python API support for reading all remaining Redis collection types.

## Changes

### New scan functions (lazy)
- `scan_sets()` - Scan Redis sets, each member becomes a row
- `scan_lists()` - Scan Redis lists, each element becomes a row with optional position
- `scan_zsets()` - Scan Redis sorted sets, member-score pairs with optional rank
- `scan_streams()` - Scan Redis streams with timestamp/sequence extraction
- `scan_timeseries()` - Scan RedisTimeSeries with aggregation support

### New read functions (eager)
- `read_sets()` - Eager version of scan_sets
- `read_lists()` - Eager version of scan_lists
- `read_zsets()` - Eager version of scan_zsets
- `read_streams()` - Eager version of scan_streams
- `read_timeseries()` - Eager version of scan_timeseries

### New options classes
- `SetScanOptions` - Configuration for set scanning
- `ListScanOptions` - Configuration for list scanning with position support
- `ZSetScanOptions` - Configuration for sorted set scanning with rank support

### Updated exports
All new functions and options are exported from `polars_redis` package.

## Example usage

```python
import polars_redis as redis

# Scan sets
lf = redis.scan_sets("redis://localhost:6379", pattern="tags:*")
df = lf.collect()

# Scan lists with position
lf = redis.scan_lists("redis://localhost:6379", pattern="queue:*", include_position=True)

# Scan sorted sets with rank
lf = redis.scan_zsets("redis://localhost:6379", pattern="leaderboard:*", include_rank=True)

# Scan streams
lf = redis.scan_streams("redis://localhost:6379", pattern="events:*")

# Scan time series with aggregation
lf = redis.scan_timeseries("redis://localhost:6379", pattern="sensor:*", aggregation="avg", bucket_size_ms=60000)
```

Closes #81, #82, #83, #84, #85