### PR TITLE
feat: add missing RediSearch query features to query builder

### DIFF
--- a/python/polars_redis/__init__.py
+++ b/python/polars_redis/__init__.py
@@ -99,7 +99,7 @@ from polars_redis.options import (
 )
 
 # Re-export query builder
-from polars_redis.query import col, raw
+from polars_redis.query import col, cols, raw
 
 __all__ = [
     # Iterators
@@ -159,6 +159,7 @@ __all__ = [
     "SearchOptions",
     # Query builder (predicate pushdown)
     "col",
+    "cols",
     "raw",
     # Environment defaults
     "get_default_batch_size",

--- a/python/polars_redis/query.py
+++ b/python/polars_redis/query.py
@@ -192,6 +192,16 @@ class Expr:
         expr._value = suffix
         return expr
 
+    def contains_substring(self, substring: str) -> Expr:
+        """Infix/contains match: col("name").contains_substring("sun") -> @name:*sun*
+
+        Matches if the substring appears anywhere in the field.
+        """
+        expr = Expr(self._field)
+        expr._op = "infix"
+        expr._value = substring
+        return expr
+
     def matches(self, pattern: str) -> Expr:
         """Wildcard match: col("name").matches("j*n") -> @name:j*n
 
@@ -199,6 +209,16 @@ class Expr:
         """
         expr = Expr(self._field)
         expr._op = "wildcard"
+        expr._value = pattern
+        return expr
+
+    def matches_exact(self, pattern: str) -> Expr:
+        """Exact wildcard match: col("name").matches_exact("foo*bar?") -> @name:"w'foo*bar?'"
+
+        Supports * (any chars) and ? (single char) wildcards with exact matching.
+        """
+        expr = Expr(self._field)
+        expr._op = "wildcard_exact"
         expr._value = pattern
         return expr
 
@@ -215,17 +235,24 @@ class Expr:
         expr._value2 = min(max(distance, 1), 3)  # Clamp to 1-3
         return expr
 
-    def phrase(self, *words: str, slop: int = 0) -> Expr:
+    def phrase(self, *words: str, slop: int | None = None, inorder: bool | None = None) -> Expr:
         """Phrase search: col("title").phrase("hello", "world") -> @title:(hello world)
 
         Args:
             *words: Words that must appear in order
-            slop: Number of intervening terms allowed (default 0 = exact)
+            slop: Number of intervening terms allowed (None = exact match)
+            inorder: Whether words must appear in order (None = any order)
+
+        Example:
+            >>> col("title").phrase("hello", "world")  # Exact phrase
+            >>> col("title").phrase("hello", "world", slop=2)  # Allow 2 words between
+            >>> col("title").phrase("hello", "world", slop=2, inorder=True)  # In order with slop
         """
         expr = Expr(self._field)
         expr._op = "phrase"
         expr._value = words
         expr._value2 = slop
+        expr._value3 = inorder
         return expr
 
     # =========================================================================
@@ -270,6 +297,59 @@ class Expr:
         expr._value4 = unit
         return expr
 
+    def within_polygon(self, points: list[tuple[float, float]]) -> Expr:
+        """Geo polygon search: col("location").within_polygon([(0,0), (0,10), (10,10), (10,0), (0,0)])
+
+        Args:
+            points: List of (lon, lat) tuples forming a closed polygon.
+                    First and last point should be the same.
+
+        Note: This generates a query that requires PARAMS to be passed.
+        The polygon WKT is stored and should be passed via PARAMS.
+        """
+        expr = Expr(self._field)
+        expr._op = "geo_polygon"
+        expr._value = points
+        return expr
+
+    # =========================================================================
+    # Vector search operations
+    # =========================================================================
+
+    def knn(self, k: int, vector_param: str = "query_vec") -> Expr:
+        """K-nearest neighbors vector search.
+
+        Args:
+            k: Number of nearest neighbors to return
+            vector_param: Parameter name for the vector (passed via PARAMS)
+
+        Example:
+            >>> col("embedding").knn(10, "query_vec")
+            >>> # Query: *=>[KNN 10 @embedding $query_vec]
+        """
+        expr = Expr(self._field)
+        expr._op = "vector_knn"
+        expr._value = k
+        expr._value2 = vector_param
+        return expr
+
+    def vector_range(self, radius: float, vector_param: str = "query_vec") -> Expr:
+        """Vector range search within a given radius.
+
+        Args:
+            radius: Search radius in vector space
+            vector_param: Parameter name for the vector (passed via PARAMS)
+
+        Example:
+            >>> col("embedding").vector_range(0.5, "query_vec")
+            >>> # Query: @embedding:[VECTOR_RANGE 0.5 $query_vec]
+        """
+        expr = Expr(self._field)
+        expr._op = "vector_range"
+        expr._value = radius
+        expr._value2 = vector_param
+        return expr
+
     # =========================================================================
     # Null checks
     # =========================================================================
@@ -302,6 +382,23 @@ class Expr:
         expr._op = "boost"
         expr._left = self
         expr._value = weight
+        return expr
+
+    def optional(self) -> Expr:
+        """Mark as optional: col("title").contains("tutorial").optional()
+
+        Documents with this term rank higher, but it's not required.
+        Generates: ~(query)
+
+        Example:
+            >>> required = col("title").contains("python")
+            >>> optional = col("title").contains("tutorial").optional()
+            >>> query = required & optional
+            >>> # Matches docs with "python", ranks "python tutorial" higher
+        """
+        expr = Expr(self._field)
+        expr._op = "optional"
+        expr._left = self
         return expr
 
     # =========================================================================
@@ -399,15 +496,25 @@ class Expr:
             return f"@{self._field}:{self._escape_text(str(self._value))}*"
         elif self._op == "suffix":
             return f"@{self._field}:*{self._escape_text(str(self._value))}"
+        elif self._op == "infix":
+            return f"@{self._field}:*{self._escape_text(str(self._value))}*"
         elif self._op == "wildcard":
             return f"@{self._field}:{str(self._value)}"
+        elif self._op == "wildcard_exact":
+            return f"@{self._field}:\"w'{self._value}'\""
         elif self._op == "fuzzy":
             pct = "%" * int(self._value2)  # 1-3 percent signs
             return f"@{self._field}:{pct}{self._escape_text(str(self._value))}{pct}"
         elif self._op == "phrase":
             words = " ".join(str(w) for w in self._value)
-            # Note: SLOP is a search option, not part of query syntax
-            # For now, just return the phrase
+            # Build query attributes for slop/inorder
+            attrs = []
+            if self._value2 is not None:  # slop
+                attrs.append(f"$slop: {self._value2}")
+            if self._value3 is not None:  # inorder
+                attrs.append(f"$inorder: {str(self._value3).lower()}")
+            if attrs:
+                return f"@{self._field}:({words}) => {{ {'; '.join(attrs)}; }}"
             return f"@{self._field}:({words})"
 
         # Tag operations
@@ -417,10 +524,29 @@ class Expr:
             tags = "|".join(self._format_value(t) for t in self._value)
             return f"@{self._field}:{{{tags}}}"
 
+        # Multi-field search
+        elif self._op == "multi_field_search":
+            fields = "|".join(self._value)
+            return f"@{fields}:{self._escape_text(str(self._value2))}"
+        elif self._op == "multi_field_prefix":
+            fields = "|".join(self._value)
+            return f"@{fields}:{self._escape_text(str(self._value2))}*"
+
         # Geo operations
         elif self._op == "geo_radius":
             # @geo:[lon lat radius unit]
             return f"@{self._field}:[{self._value} {self._value2} {self._value3} {self._value4}]"
+        elif self._op == "geo_polygon":
+            # Polygon requires PARAMS - query just references the param
+            return f"@{self._field}:[WITHIN $poly]"
+
+        # Vector search
+        elif self._op == "vector_knn":
+            # *=>[KNN k @field $param]
+            return f"*=>[KNN {self._value} @{self._field} ${self._value2}]"
+        elif self._op == "vector_range":
+            # @field:[VECTOR_RANGE radius $param]
+            return f"@{self._field}:[VECTOR_RANGE {self._value} ${self._value2}]"
 
         # Null checks
         elif self._op == "is_null":
@@ -433,6 +559,11 @@ class Expr:
         elif self._op == "boost":
             inner = self._left.to_redis() if self._left else "*"
             return f"({inner}) => {{ $weight: {self._value}; }}"
+
+        # Optional terms
+        elif self._op == "optional":
+            inner = self._left.to_redis() if self._left else "*"
+            return f"~{inner}"
 
         # Raw/fallback
         elif self._op == "raw":
@@ -529,3 +660,45 @@ def match_all() -> Expr:
 def match_none() -> Expr:
     """Match no documents."""
     return raw("-*")
+
+
+def cols(*names: str) -> MultiFieldExpr:
+    """Create a multi-field expression for searching across multiple fields.
+
+    Args:
+        *names: Field names to search across.
+
+    Returns:
+        A MultiFieldExpr that generates @field1|field2|...:term queries.
+
+    Example:
+        >>> from polars_redis.query import cols
+        >>>
+        >>> # Search across title and body
+        >>> cols("title", "body").contains("python")
+        >>> # Generates: @title|body:python
+    """
+    return MultiFieldExpr(list(names))
+
+
+class MultiFieldExpr:
+    """Expression for searching across multiple fields."""
+
+    def __init__(self, fields: list[str]):
+        self._fields = fields
+
+    def contains(self, text: str) -> Expr:
+        """Full-text search across all fields."""
+        expr = Expr("")
+        expr._op = "multi_field_search"
+        expr._value = self._fields
+        expr._value2 = text
+        return expr
+
+    def starts_with(self, prefix: str) -> Expr:
+        """Prefix match across all fields."""
+        expr = Expr("")
+        expr._op = "multi_field_prefix"
+        expr._value = self._fields
+        expr._value2 = prefix
+        return expr


### PR DESCRIPTION
This PR adds comprehensive RediSearch query features to the query builder, making the search functionality much more complete.

## New Features

### High Priority (from Issue #93)

1. **Optional terms** (`~bar` syntax)
   ```python
   # Python
   col("title").contains("tutorial").optional()
   # Generates: ~@title:tutorial
   ```
   ```rust
   // Rust
   Predicate::text_search("title", "tutorial").optional()
   ```

2. **Infix/substring matching** (`*sun*`)
   ```python
   col("name").contains_substring("sun")  # @name:*sun*
   ```

3. **Phrase with slop/inorder**
   ```python
   col("title").phrase("hello", "world", slop=2, inorder=True)
   # @title:(hello world) => { $slop: 2; $inorder: true; }
   ```

### Medium Priority

4. **Exact wildcard patterns** (`w'foo*bar?'`)
   ```python
   col("name").matches_exact("foo*bar?")
   # @name:"w'foo*bar?'"
   ```

5. **Multi-field search**
   ```python
   cols("title", "body").contains("python")
   # @title|body:python
   ```

6. **Geo polygon search**
   ```python
   col("location").within_polygon([(0,0), (0,10), (10,10), (10,0), (0,0)])
   # @location:[WITHIN $poly]
   ```

### Lower Priority

7. **Vector KNN search**
   ```python
   col("embedding").knn(k=10, vector_param="query_vec")
   # *=>[KNN 10 @embedding $query_vec]
   ```

8. **Vector range search**
   ```python
   col("embedding").vector_range(radius=0.5, vector_param="query_vec")
   # @embedding:[VECTOR_RANGE 0.5 $query_vec]
   ```

## Implementation Details

### Rust (src/query_builder.rs)
- Added new `Predicate` variants: `Infix`, `WildcardExact`, `PhraseWithOptions`, `Optional`, `MultiFieldSearch`, `GeoPolygon`, `VectorKnn`, `VectorRange`
- Added `get_params()` method for extracting PARAMS needed by complex queries (geo polygon, vectors)
- All new features have comprehensive tests (14 new tests)

### Python (python/polars_redis/query.py)
- Added methods: `contains_substring()`, `matches_exact()`, `optional()`, `within_polygon()`, `knn()`, `vector_range()`
- Enhanced `phrase()` with `slop` and `inorder` parameters
- Added `cols()` function and `MultiFieldExpr` class for multi-field search
- Updated `__init__.py` exports

## Tests
- 273 Rust tests passing (14 new query builder tests)
- Python syntax validated

Closes #93