### PR TITLE
docs: add prominent Polars links and primer slide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # polars-redis
 
-Query Redis like a database. Transform with Polars. Write back without ETL.
+Query Redis like a database. Transform with [Polars](https://pola.rs/). Write back without ETL.
+
+> **New to Polars?** [Polars](https://pola.rs/) is a lightning-fast DataFrame library for Python and Rust. Check out the [Polars User Guide](https://docs.pola.rs/) to get started.
 
 [![CI](https://github.com/joshrotenberg/polars-redis/actions/workflows/ci.yml/badge.svg)](https://github.com/joshrotenberg/polars-redis/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/polars-redis.svg)](https://pypi.org/project/polars-redis/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,9 @@
 # polars-redis
 
-Query Redis like a database. Transform with Polars. Write back without ETL.
+Query Redis like a database. Transform with [Polars](https://pola.rs/). Write back without ETL.
+
+!!! tip "New to Polars?"
+    [Polars](https://pola.rs/) is a lightning-fast DataFrame library for Python and Rust, designed for performance and ease of use. Check out the [Polars User Guide](https://docs.pola.rs/) to get started.
 
 polars-redis brings Redis into your Polars analytics workflows as a first-class data source - scan hashes, JSON, strings, sets, lists, and sorted sets directly into LazyFrames with projection pushdown and batched iteration.
 

--- a/docs/slides.md
+++ b/docs/slides.md
@@ -12,6 +12,7 @@ An interactive slide deck covering polars-redis features and usage.
 
 ## Topics Covered
 
+- What is Polars? (quick primer)
 - What is polars-redis?
 - Scanning Redis Hashes and JSON
 - Writing DataFrames to Redis

--- a/docs/slides/index.html
+++ b/docs/slides/index.html
@@ -195,6 +195,61 @@ df = pr.search_hashes(
                     </ul>
                 </section>
 
+                <!-- Polars Primer -->
+                <section>
+                    <h2>What is <span class="polars-blue">Polars</span>?</h2>
+                    <p>
+                        <a href="https://pola.rs/" style="color: #4b8bbe"
+                            >pola.rs</a
+                        >
+                        - A lightning-fast DataFrame library for Python and Rust
+                    </p>
+                    <div class="columns">
+                        <div class="column">
+                            <h3 class="polars-blue">Key Features</h3>
+                            <ul>
+                                <li>
+                                    <span class="green">Blazingly fast</span> -
+                                    Written in Rust, multi-threaded
+                                </li>
+                                <li>
+                                    <span class="green">Lazy evaluation</span> -
+                                    Query optimization before execution
+                                </li>
+                                <li>
+                                    <span class="green">Memory efficient</span>
+                                    - Apache Arrow columnar format
+                                </li>
+                                <li>
+                                    <span class="green">Expressive API</span> -
+                                    Chain operations fluently
+                                </li>
+                            </ul>
+                        </div>
+                        <div class="column">
+                            <h3 class="orange">Quick Example</h3>
+                            <pre><code class="language-python">import polars as pl
+
+# Read, transform, write
+df = pl.read_csv("data.csv")
+result = (
+    df.filter(pl.col("age") > 25)
+      .group_by("department")
+      .agg(pl.col("salary").mean())
+      .sort("salary", descending=True)
+)
+result.write_parquet("output.parquet")</code></pre>
+                        </div>
+                    </div>
+                    <p class="small" style="margin-top: 0.5em">
+                        <span class="green">Learn more:</span>
+                        <a href="https://docs.pola.rs/" style="color: #98c379"
+                            >docs.pola.rs</a
+                        >
+                        - Polars User Guide
+                    </p>
+                </section>
+
                 <!-- What is polars-redis? -->
                 <section>
                     <h2>What is polars-redis?</h2>


### PR DESCRIPTION
## Summary

Adds more prominent Polars links early in the documentation and a quick primer slide for users new to Polars.

## Changes

### README.md
- Made "Polars" in tagline a link to pola.rs
- Added callout block for newcomers with links to Polars and User Guide

### docs/index.md
- Made "Polars" in tagline a link to pola.rs
- Added tip admonition for newcomers with links to Polars docs

### docs/slides/index.html
- Added new "What is Polars?" slide after the solution slide:
  - Key features: fast, lazy evaluation, memory efficient, expressive API
  - Quick code example showing typical Polars workflow
  - Links to pola.rs and docs.pola.rs

### docs/slides.md
- Updated topics list to include "What is Polars? (quick primer)"