### PR TITLE
docs: add API documentation for query builder and error handling

### DIFF
--- a/docs/api/python.md
+++ b/docs/api/python.md
@@ -557,6 +557,189 @@ Write a DataFrame to Redis as sorted sets.
 
 ---
 
+## Detailed Write Functions
+
+### write_hashes_detailed
+
+```python
+def write_hashes_detailed(
+    df: pl.DataFrame,
+    url: str,
+    key_column: str | None = "_key",
+    ttl: int | None = None,
+    key_prefix: str = "",
+    if_exists: str = "replace",
+) -> WriteResult
+```
+
+Write a DataFrame to Redis as hashes with detailed error reporting.
+
+**Parameters:** Same as `write_hashes`.
+
+**Returns:** `WriteResult` object with per-key success/failure information.
+
+---
+
+### WriteResult
+
+```python
+class WriteResult:
+    keys_written: int      # Number of keys successfully written
+    keys_failed: int       # Number of keys that failed
+    keys_skipped: int      # Number of keys skipped (if_exists="fail")
+    succeeded_keys: list[str]  # List of successfully written keys
+    failed_keys: list[str]     # List of keys that failed
+    errors: dict[str, str]     # Map of failed keys to error messages
+
+    def is_complete_success(self) -> bool:
+        """Check if all keys were written successfully."""
+```
+
+---
+
+## Query Builder
+
+### col
+
+```python
+def col(name: str) -> Expr
+```
+
+Create a column expression for building RediSearch queries.
+
+**Parameters:**
+
+- `name`: Field name to query
+
+**Returns:** `Expr` object
+
+---
+
+### cols
+
+```python
+def cols(*names: str) -> MultiFieldExpr
+```
+
+Create a multi-field expression for searching across multiple fields.
+
+**Parameters:**
+
+- `*names`: Field names to search across
+
+**Returns:** `MultiFieldExpr` object
+
+---
+
+### raw
+
+```python
+def raw(query: str) -> Expr
+```
+
+Create a raw RediSearch query expression.
+
+**Parameters:**
+
+- `query`: Raw RediSearch query string
+
+**Returns:** `Expr` object
+
+---
+
+### Expr Methods
+
+#### Comparison Operators
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `>` | Greater than | `col("age") > 30` |
+| `>=` | Greater or equal | `col("age") >= 30` |
+| `<` | Less than | `col("age") < 30` |
+| `<=` | Less or equal | `col("age") <= 30` |
+| `==` | Equal | `col("status") == "active"` |
+| `!=` | Not equal | `col("status") != "deleted"` |
+
+#### Logical Operators
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `&` | AND | `(col("a") > 1) & (col("b") < 2)` |
+| `\|` | OR | `(col("a") == 1) \| (col("a") == 2)` |
+| `~` | NOT | `~(col("status") == "deleted")` |
+
+#### Range and Membership
+
+```python
+Expr.is_between(lower, upper) -> Expr
+Expr.is_in(values: list) -> Expr
+```
+
+#### Text Search
+
+```python
+Expr.contains(text: str) -> Expr           # Full-text search
+Expr.starts_with(prefix: str) -> Expr      # Prefix match
+Expr.ends_with(suffix: str) -> Expr        # Suffix match
+Expr.contains_substring(text: str) -> Expr # Infix/substring match
+Expr.matches(pattern: str) -> Expr         # Wildcard match
+Expr.matches_exact(pattern: str) -> Expr   # Exact wildcard match
+Expr.fuzzy(term: str, distance: int = 1) -> Expr  # Fuzzy match (distance 1-3)
+Expr.phrase(*words: str, slop: int = None, inorder: bool = None) -> Expr
+```
+
+#### Tag Operations
+
+```python
+Expr.has_tag(tag: str) -> Expr
+Expr.has_any_tag(tags: list[str]) -> Expr
+```
+
+#### Geo Operations
+
+```python
+Expr.within_radius(lon: float, lat: float, radius: float, unit: str = "km") -> Expr
+Expr.within_polygon(points: list[tuple[float, float]]) -> Expr
+```
+
+#### Vector Search
+
+```python
+Expr.knn(k: int, vector_param: str = "query_vec") -> Expr
+Expr.vector_range(radius: float, vector_param: str = "query_vec") -> Expr
+```
+
+#### Relevance
+
+```python
+Expr.boost(weight: float) -> Expr    # Increase relevance weight
+Expr.optional() -> Expr              # Mark as optional (prefer but don't require)
+```
+
+#### Null Checks
+
+```python
+Expr.is_null() -> Expr
+Expr.is_not_null() -> Expr
+```
+
+#### Query Output
+
+```python
+Expr.to_redis() -> str  # Convert to RediSearch query string
+```
+
+---
+
+### MultiFieldExpr Methods
+
+```python
+MultiFieldExpr.contains(text: str) -> Expr      # Search across all fields
+MultiFieldExpr.starts_with(prefix: str) -> Expr # Prefix match across fields
+```
+
+---
+
 ## Schema Inference
 
 ### infer_hash_schema

--- a/docs/guide/redisearch.md
+++ b/docs/guide/redisearch.md
@@ -132,6 +132,217 @@ query = raw("@name:ali*")
 query = raw("@name:alice") & (col("age") > 25)
 ```
 
+## Advanced Query Features
+
+### Text Search
+
+#### Full-text Search
+
+```python
+# Basic text search (with stemming)
+query = col("title").contains("python")
+# @title:python
+
+# Prefix matching
+query = col("name").starts_with("jo")
+# @name:jo*
+
+# Suffix matching
+query = col("name").ends_with("son")
+# @name:*son
+
+# Substring/infix matching
+query = col("description").contains_substring("data")
+# @description:*data*
+```
+
+#### Fuzzy Matching
+
+Match terms with typos using Levenshtein distance (1-3):
+
+```python
+# Allow 1 character difference
+query = col("title").fuzzy("python", distance=1)
+# @title:%python%
+
+# Allow 2 character differences
+query = col("title").fuzzy("algorithm", distance=2)
+# @title:%%algorithm%%
+```
+
+#### Phrase Search
+
+Search for phrases with optional slop and order control:
+
+```python
+# Exact phrase (words must appear consecutively)
+query = col("title").phrase("hello", "world")
+# @title:(hello world)
+
+# Allow words between (slop = max intervening terms)
+query = col("title").phrase("machine", "learning", slop=2)
+# @title:(machine learning) => { $slop: 2; }
+
+# Require in-order with slop
+query = col("title").phrase("data", "science", slop=3, inorder=True)
+# @title:(data science) => { $slop: 3; $inorder: true; }
+```
+
+#### Wildcard Matching
+
+```python
+# Simple wildcard
+query = col("name").matches("j*n")
+# @name:j*n
+
+# Exact wildcard matching
+query = col("code").matches_exact("FOO*BAR?")
+# @code:"w'FOO*BAR?'"
+```
+
+### Multi-field Search
+
+Search across multiple fields simultaneously:
+
+```python
+from polars_redis import cols
+
+# Search title and body together
+query = cols("title", "body").contains("python")
+# @title|body:python
+
+# Prefix search across fields
+query = cols("first_name", "last_name").starts_with("john")
+# @first_name|last_name:john*
+```
+
+### Tag Operations
+
+```python
+# Single tag match
+query = col("category").has_tag("electronics")
+# @category:{electronics}
+
+# Match any of multiple tags
+query = col("tags").has_any_tag(["urgent", "important"])
+# @tags:{urgent|important}
+```
+
+### Geo Search
+
+#### Radius Search
+
+```python
+# Find locations within 10km of a point
+query = col("location").within_radius(-122.4194, 37.7749, 10, "km")
+# @location:[-122.4194 37.7749 10 km]
+
+# Supported units: m, km, mi, ft
+query = col("location").within_radius(-73.9857, 40.7484, 5, "mi")
+```
+
+#### Polygon Search
+
+Search within a polygon boundary:
+
+```python
+# Define polygon as list of (lon, lat) points
+polygon = [
+    (-122.5, 37.7),
+    (-122.5, 37.8),
+    (-122.3, 37.8),
+    (-122.3, 37.7),
+    (-122.5, 37.7),  # Close the polygon
+]
+query = col("location").within_polygon(polygon)
+# @location:[WITHIN $poly]
+```
+
+!!! note
+    Polygon queries require passing the polygon as a query parameter. The query builder generates a parameterized query.
+
+### Vector Search
+
+For semantic similarity search with vector embeddings:
+
+#### K-Nearest Neighbors (KNN)
+
+```python
+# Find 10 most similar documents
+query = col("embedding").knn(10, "query_vec")
+# *=>[KNN 10 @embedding $query_vec]
+
+# Use with search_hashes (pass vector as parameter)
+df = redis.search_hashes(
+    url,
+    index="docs_idx",
+    query=query,
+    schema={"title": pl.Utf8, "embedding": pl.List(pl.Float32)},
+    params={"query_vec": embedding_bytes},
+)
+```
+
+#### Vector Range Search
+
+Find all vectors within a distance threshold:
+
+```python
+# Find all documents within distance 0.5
+query = col("embedding").vector_range(0.5, "query_vec")
+# @embedding:[VECTOR_RANGE 0.5 $query_vec]
+```
+
+### Relevance Tuning
+
+#### Boosting
+
+Increase the relevance score contribution of specific terms:
+
+```python
+# Boost title matches 2x
+query = col("title").contains("python").boost(2.0)
+# (@title:python) => { $weight: 2.0; }
+
+# Combine with other terms
+title_query = col("title").contains("python").boost(2.0)
+body_query = col("body").contains("python")
+query = title_query | body_query
+```
+
+#### Optional Terms
+
+Mark terms as optional for better ranking without requiring them:
+
+```python
+# Documents with "python" required, "tutorial" optional but preferred
+required = col("title").contains("python")
+optional = col("title").contains("tutorial").optional()
+query = required & optional
+# @title:python ~@title:tutorial
+```
+
+### Null Checks
+
+```python
+# Find documents missing a field
+query = col("email").is_null()
+# ismissing(@email)
+
+# Find documents with a field present
+query = col("email").is_not_null()
+# -ismissing(@email)
+```
+
+### Debugging Queries
+
+Use `to_redis()` to inspect the generated RediSearch query:
+
+```python
+query = (col("type") == "eBikes") & (col("price") < 1000)
+print(query.to_redis())
+# @type:{eBikes} @price:[-inf (1000]
+```
+
 ## Aggregation with aggregate_hashes()
 
 `aggregate_hashes()` uses FT.AGGREGATE for server-side grouping and aggregation:

--- a/python/polars_redis/query.py
+++ b/python/polars_redis/query.py
@@ -444,7 +444,36 @@ class Expr:
     # =========================================================================
 
     def to_redis(self) -> str:
-        """Convert the expression to a RediSearch query string."""
+        """Convert this expression to a RediSearch query string.
+
+        Returns the query in RediSearch syntax that will be sent to Redis
+        when using search_hashes() or search_json(). This is useful for:
+
+        - Debugging queries to see the generated RediSearch syntax
+        - Understanding what will be sent to Redis
+        - Copying the query for use with redis-cli or other tools
+
+        Returns:
+            str: RediSearch query string in FT.SEARCH syntax.
+
+        Example:
+            >>> from polars_redis.query import col
+            >>>
+            >>> # Simple comparison
+            >>> query = col("age") > 30
+            >>> print(query.to_redis())
+            '@age:[(30 +inf]'
+            >>>
+            >>> # Combined conditions
+            >>> query = (col("type") == "eBikes") & (col("price") < 1000)
+            >>> print(query.to_redis())
+            '@type:{eBikes} @price:[-inf (1000]'
+            >>>
+            >>> # Text search with fuzzy matching
+            >>> query = col("title").fuzzy("python", distance=1)
+            >>> print(query.to_redis())
+            '@title:%python%'
+        """
 
         # Comparison operators
         if self._op == "gt":

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -262,6 +262,31 @@ fn parse_datetime_parts(date_str: &str, time_str: &str) -> Option<i64> {
 }
 
 /// Schema for a Redis hash, mapping field names to types.
+///
+/// Defines how Redis hash fields should be converted to Arrow/Polars columns.
+/// Each field is mapped to a [`RedisType`] which determines parsing behavior.
+///
+/// # Example
+///
+/// ```ignore
+/// use polars_redis::{HashSchema, RedisType};
+///
+/// let schema = HashSchema::new(vec![
+///     ("name".to_string(), RedisType::Utf8),
+///     ("age".to_string(), RedisType::Int64),
+///     ("score".to_string(), RedisType::Float64),
+///     ("active".to_string(), RedisType::Boolean),
+/// ])
+/// .with_key(true)
+/// .with_key_column_name("_key")
+/// .with_ttl(true);
+/// ```
+///
+/// # Optional Metadata Columns
+///
+/// - Key column: Include the Redis key as a column (default: true, name: "_key")
+/// - TTL column: Include the key's TTL in seconds (default: false, name: "_ttl")
+/// - Row index: Include a row number column (default: false, name: "_index")
 #[derive(Debug, Clone)]
 pub struct HashSchema {
     /// Ordered list of field names.

--- a/src/types/json/convert.rs
+++ b/src/types/json/convert.rs
@@ -14,7 +14,31 @@ use arrow::datatypes::{DataType, Field, Schema};
 use super::reader::JsonData;
 use crate::error::{Error, Result};
 
-/// Schema for JSON documents, mapping field names to expected types.
+/// Schema for RedisJSON documents, mapping JSONPath expressions to Arrow types.
+///
+/// Defines how RedisJSON document fields should be extracted and converted to
+/// Arrow/Polars columns. Uses JSONPath notation for field access.
+///
+/// # Example
+///
+/// ```ignore
+/// use polars_redis::JsonSchema;
+/// use arrow::datatypes::DataType;
+///
+/// let schema = JsonSchema::new(vec![
+///     ("$.name".to_string(), DataType::Utf8),
+///     ("$.user.age".to_string(), DataType::Int64),
+///     ("$.metadata.score".to_string(), DataType::Float64),
+/// ])
+/// .with_key(true)
+/// .with_ttl(true);
+/// ```
+///
+/// # Optional Metadata Columns
+///
+/// - Key column: Include the Redis key as a column (default: true, name: "_key")
+/// - TTL column: Include the key's TTL in seconds (default: false, name: "_ttl")
+/// - Row index: Include a row number column (default: false, name: "_index")
 #[derive(Debug, Clone)]
 pub struct JsonSchema {
     /// Ordered list of field names to extract.

--- a/src/types/list/convert.rs
+++ b/src/types/list/convert.rs
@@ -9,6 +9,27 @@ use super::reader::ListData;
 use crate::error::Result;
 
 /// Schema configuration for Redis list scanning.
+///
+/// Defines output columns when scanning Redis lists. Each list element becomes
+/// a row in the output DataFrame.
+///
+/// # Example
+///
+/// ```ignore
+/// use polars_redis::ListSchema;
+///
+/// let schema = ListSchema::new()
+///     .with_key(true)
+///     .with_position(true)  // Include element position in list
+///     .with_element_column_name("item");
+/// ```
+///
+/// # Output Schema
+///
+/// - `_key` (optional): The Redis key
+/// - `element`: The list element value (Utf8)
+/// - `position` (optional): Element's position in the list (Int64)
+/// - `_index` (optional): Global row number
 #[derive(Debug, Clone)]
 pub struct ListSchema {
     /// Whether to include the Redis key as a column.

--- a/src/types/set/batch_iter.rs
+++ b/src/types/set/batch_iter.rs
@@ -10,7 +10,31 @@ use crate::connection::RedisConnection;
 use crate::error::{Error, Result};
 use crate::types::hash::BatchConfig;
 
-/// Iterator for scanning Redis sets and yielding Arrow RecordBatches.
+/// Iterator for scanning Redis sets in batches as Arrow RecordBatches.
+///
+/// This iterator fetches set keys matching a pattern and retrieves their
+/// members, converting them to Arrow RecordBatches for use with Polars.
+/// Each member becomes a row in the output.
+///
+/// # Example
+///
+/// ```ignore
+/// use polars_redis::{SetBatchIterator, SetSchema, BatchConfig};
+///
+/// let schema = SetSchema::new().with_key(true);
+/// let config = BatchConfig::new("tags:*").with_batch_size(1000);
+///
+/// let mut iterator = SetBatchIterator::new(url, schema, config)?;
+///
+/// while let Some(batch) = iterator.next_batch()? {
+///     println!("Got {} members", batch.num_rows());
+/// }
+/// ```
+///
+/// # Output Schema
+///
+/// - `_key` (optional): The Redis key
+/// - `member`: The set member value (Utf8)
 pub struct SetBatchIterator {
     /// Tokio runtime for async operations.
     runtime: Runtime,

--- a/src/types/set/convert.rs
+++ b/src/types/set/convert.rs
@@ -9,6 +9,25 @@ use super::reader::SetData;
 use crate::error::Result;
 
 /// Schema configuration for Redis set scanning.
+///
+/// Defines output columns when scanning Redis sets. Each set member becomes
+/// a row in the output DataFrame.
+///
+/// # Example
+///
+/// ```ignore
+/// use polars_redis::SetSchema;
+///
+/// let schema = SetSchema::new()
+///     .with_key(true)
+///     .with_member_column_name("tag");
+/// ```
+///
+/// # Output Schema
+///
+/// - `_key` (optional): The Redis key
+/// - `member`: The set member value (Utf8)
+/// - `_index` (optional): Row number
 #[derive(Debug, Clone)]
 pub struct SetSchema {
     /// Whether to include the Redis key as a column.

--- a/src/types/stream/convert.rs
+++ b/src/types/stream/convert.rs
@@ -9,6 +9,33 @@ use super::reader::StreamData;
 use crate::error::Result;
 
 /// Schema configuration for Redis Stream scanning.
+///
+/// Defines output columns when scanning Redis Streams. Each stream entry becomes
+/// a row in the output DataFrame.
+///
+/// # Example
+///
+/// ```ignore
+/// use polars_redis::StreamSchema;
+///
+/// let schema = StreamSchema::new(vec![
+///     "user_id".to_string(),
+///     "action".to_string(),
+///     "payload".to_string(),
+/// ])
+/// .with_key(true)
+/// .with_id(true)
+/// .with_timestamp(true);
+/// ```
+///
+/// # Output Schema
+///
+/// - `_key` (optional): The Redis stream key
+/// - `_id` (optional): The entry ID (e.g., "1234567890123-0")
+/// - `_timestamp` (optional): Timestamp extracted from entry ID (Int64 ms)
+/// - `_sequence` (optional): Sequence number from entry ID
+/// - User-defined fields extracted from entry data
+/// - `_index` (optional): Global row number
 #[derive(Debug, Clone)]
 pub struct StreamSchema {
     /// Whether to include the Redis key as a column.

--- a/src/types/string/convert.rs
+++ b/src/types/string/convert.rs
@@ -14,7 +14,32 @@ use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 use super::reader::StringData;
 use crate::error::{Error, Result};
 
-/// Schema for Redis string values.
+/// Schema for Redis string values, defining how to parse and convert them.
+///
+/// Redis strings are simple key-value pairs. This schema defines what type
+/// the values should be parsed as (e.g., Int64 for counters, Utf8 for text).
+///
+/// # Example
+///
+/// ```ignore
+/// use polars_redis::StringSchema;
+/// use arrow::datatypes::DataType;
+///
+/// // For string counters
+/// let schema = StringSchema::new(DataType::Int64)
+///     .with_key(true)
+///     .with_value_column_name("count");
+///
+/// // For text values
+/// let schema = StringSchema::new(DataType::Utf8)
+///     .with_key(true);
+/// ```
+///
+/// # Output Schema
+///
+/// - `_key` (optional): The Redis key
+/// - `value`: The parsed value (type depends on schema)
+/// - `_ttl` (optional): TTL in seconds
 #[derive(Debug, Clone)]
 pub struct StringSchema {
     /// The Arrow DataType for values.

--- a/src/types/timeseries/batch_iter.rs
+++ b/src/types/timeseries/batch_iter.rs
@@ -10,7 +10,37 @@ use crate::connection::RedisConnection;
 use crate::error::{Error, Result};
 use crate::types::hash::BatchConfig;
 
-/// Iterator for scanning RedisTimeSeries and yielding Arrow RecordBatches.
+/// Iterator for scanning RedisTimeSeries in batches as Arrow RecordBatches.
+///
+/// This iterator fetches time series keys matching a pattern and retrieves their
+/// samples, converting them to Arrow RecordBatches for use with Polars.
+/// Each sample becomes a row in the output.
+///
+/// Requires the RedisTimeSeries module to be loaded on the Redis server.
+///
+/// # Example
+///
+/// ```ignore
+/// use polars_redis::{TimeSeriesBatchIterator, TimeSeriesSchema, BatchConfig};
+///
+/// let schema = TimeSeriesSchema::new().with_key(true).with_labels(true);
+/// let config = BatchConfig::new("ts:sensor:*").with_batch_size(1000);
+///
+/// let mut iterator = TimeSeriesBatchIterator::new(url, schema, config)?
+///     .with_range("-", "+")
+///     .with_aggregation("avg", 60000); // 1-minute average
+///
+/// while let Some(batch) = iterator.next_batch()? {
+///     println!("Got {} samples", batch.num_rows());
+/// }
+/// ```
+///
+/// # Output Schema
+///
+/// - `_key` (optional): The Redis time series key
+/// - `timestamp`: The sample timestamp (Int64 milliseconds)
+/// - `value`: The sample value (Float64)
+/// - Label columns (optional): Time series labels as additional columns
 pub struct TimeSeriesBatchIterator {
     /// Tokio runtime for async operations.
     runtime: Runtime,

--- a/src/types/timeseries/convert.rs
+++ b/src/types/timeseries/convert.rs
@@ -9,6 +9,30 @@ use super::reader::TimeSeriesData;
 use crate::error::Result;
 
 /// Schema configuration for RedisTimeSeries scanning.
+///
+/// Defines output columns when scanning RedisTimeSeries data. Each sample becomes
+/// a row in the output DataFrame.
+///
+/// Requires the RedisTimeSeries module to be loaded on the Redis server.
+///
+/// # Example
+///
+/// ```ignore
+/// use polars_redis::TimeSeriesSchema;
+///
+/// let schema = TimeSeriesSchema::new()
+///     .with_key(true)
+///     .with_labels(vec!["sensor".to_string(), "location".to_string()])
+///     .with_value_column_name("temperature");
+/// ```
+///
+/// # Output Schema
+///
+/// - `_key` (optional): The Redis time series key
+/// - `_ts`: Timestamp in milliseconds (Int64)
+/// - `value`: Sample value (Float64)
+/// - Label columns (optional): Time series labels as additional columns
+/// - `_index` (optional): Global row number
 #[derive(Debug, Clone)]
 pub struct TimeSeriesSchema {
     /// Whether to include the Redis key as a column.

--- a/src/types/zset/convert.rs
+++ b/src/types/zset/convert.rs
@@ -11,6 +11,29 @@ use super::reader::ZSetData;
 use crate::error::Result;
 
 /// Schema configuration for Redis sorted set scanning.
+///
+/// Defines output columns when scanning Redis sorted sets. Each member becomes
+/// a row in the output DataFrame, including its score.
+///
+/// # Example
+///
+/// ```ignore
+/// use polars_redis::ZSetSchema;
+///
+/// let schema = ZSetSchema::new()
+///     .with_key(true)
+///     .with_rank(true)  // Include member's rank
+///     .with_member_column_name("player")
+///     .with_score_column_name("points");
+/// ```
+///
+/// # Output Schema
+///
+/// - `_key` (optional): The Redis key
+/// - `member`: The sorted set member value (Utf8)
+/// - `score`: The member's score (Float64)
+/// - `rank` (optional): Member's rank by score (Int64)
+/// - `_index` (optional): Global row number
 #[derive(Debug, Clone)]
 pub struct ZSetSchema {
     /// Whether to include the Redis key as a column.


### PR DESCRIPTION
This PR adds comprehensive documentation for recent API additions.

## Changes

### Issue #102: Expr.to_redis() docstring
- Added detailed docstring with examples to the `to_redis()` method

### Issue #103: Rust doc comments
- Added doc comments to all batch iterator structs (Hash, JSON, String, Set, List, ZSet, Stream, TimeSeries)
- Added doc comments to all schema structs with examples and metadata column documentation

### Issue #100: Schema inference confidence scores
- Documented `infer_hash_schema_with_confidence()` and `SchemaConfidence` class
- Documented `low_confidence_fields()` method
- Documented schema overwrite functions for hashes and JSON

### Issue #101: Detailed write error reporting
- Added "Detailed Error Handling" section to writing guide
- Documented `WriteResult` class with all properties
- Added retry pattern example for production workflows

### Issue #99: Advanced query builder features
- Documented vector search (knn, vector_range)
- Documented geo operations (within_radius, within_polygon)
- Documented text search (fuzzy, phrase, contains_substring, matches_exact)
- Documented relevance tuning (optional, boost)
- Documented multi-field search (cols)
- Updated Python API reference with complete query builder documentation

Closes #99, closes #100, closes #101, closes #102, closes #103