### PR TITLE
feat: add DataFrame caching decorator

### DIFF
--- a/python/polars_redis/__init__.py
+++ b/python/polars_redis/__init__.py
@@ -35,6 +35,10 @@ from polars_redis._cache import (
     get_cached_dataframe,
     scan_cached,
 )
+from polars_redis._decorator import (
+    cache,
+    cache_lazy,
+)
 
 # Re-export from submodules
 from polars_redis._infer import (
@@ -179,6 +183,9 @@ __all__ = [
     "cache_exists",
     "cache_ttl",
     "cache_info",
+    # Caching decorators
+    "cache",
+    "cache_lazy",
     # Environment defaults
     "get_default_batch_size",
     "get_default_count_hint",

--- a/python/polars_redis/_decorator.py
+++ b/python/polars_redis/_decorator.py
@@ -1,0 +1,395 @@
+"""DataFrame caching decorator for polars-redis.
+
+This module provides decorators that automatically cache function results
+(DataFrames) in Redis, similar to functools.lru_cache but distributed.
+"""
+
+from __future__ import annotations
+
+import functools
+import hashlib
+import inspect
+import json
+from typing import Any, Callable, Literal, TypeVar
+
+import polars as pl
+
+from polars_redis._cache import (
+    cache_dataframe,
+    cache_exists,
+    delete_cached,
+    get_cached_dataframe,
+)
+
+F = TypeVar("F", bound=Callable[..., pl.DataFrame])
+LF = TypeVar("LF", bound=Callable[..., pl.LazyFrame])
+
+
+def _make_hashable(obj: Any) -> Any:
+    """Convert an object to a hashable representation."""
+    if obj is None or isinstance(obj, (str, int, float, bool)):
+        return obj
+    elif isinstance(obj, (list, tuple)):
+        return tuple(_make_hashable(item) for item in obj)
+    elif isinstance(obj, dict):
+        return tuple(sorted((k, _make_hashable(v)) for k, v in obj.items()))
+    elif isinstance(obj, set):
+        return tuple(sorted(_make_hashable(item) for item in obj))
+    elif isinstance(obj, (pl.DataFrame, pl.LazyFrame)):
+        # DataFrames are not hashable - use schema + shape as approximation
+        if isinstance(obj, pl.LazyFrame):
+            schema = obj.collect_schema()
+            return ("LazyFrame", tuple(schema.items()))
+        return ("DataFrame", obj.shape, tuple(obj.schema.items()))
+    else:
+        # Try to convert to string representation
+        try:
+            return repr(obj)
+        except Exception:
+            raise TypeError(f"Unhashable argument type: {type(obj).__name__}")
+
+
+def _generate_cache_key(
+    prefix: str,
+    func: Callable,
+    args: tuple,
+    kwargs: dict,
+    key_fn: Callable[..., str] | None = None,
+) -> str:
+    """Generate a cache key for a function call."""
+    if key_fn is not None:
+        # Use custom key function
+        custom_key = key_fn(*args, **kwargs)
+        return f"{prefix}:{func.__module__}.{func.__qualname__}:{custom_key}"
+
+    # Build key from function signature and arguments
+    sig = inspect.signature(func)
+    bound = sig.bind(*args, **kwargs)
+    bound.apply_defaults()
+
+    # Create a hashable representation of arguments
+    args_repr = _make_hashable(dict(bound.arguments))
+    args_hash = hashlib.sha256(json.dumps(args_repr, sort_keys=True).encode()).hexdigest()[:16]
+
+    return f"{prefix}:{func.__module__}.{func.__qualname__}:{args_hash}"
+
+
+class CachedFunction:
+    """Wrapper for a cached function with cache control methods."""
+
+    def __init__(
+        self,
+        func: Callable[..., pl.DataFrame],
+        url: str,
+        ttl: int | None = None,
+        key_prefix: str = "polars_redis:cache",
+        key_fn: Callable[..., str] | None = None,
+        format: Literal["ipc", "parquet"] = "ipc",
+        compression: str | None = None,
+        chunk_size_mb: int | None = None,
+    ):
+        self._func = func
+        self._url = url
+        self._ttl = ttl
+        self._key_prefix = key_prefix
+        self._key_fn = key_fn
+        self._format = format
+        self._compression = compression
+        self._chunk_size_mb = chunk_size_mb
+
+        # Preserve function metadata
+        functools.update_wrapper(self, func)
+
+    def __call__(
+        self,
+        *args,
+        _cache_refresh: bool = False,
+        _cache_skip: bool = False,
+        **kwargs,
+    ) -> pl.DataFrame:
+        """Call the function, using cache if available.
+
+        Args:
+            *args: Positional arguments for the wrapped function.
+            _cache_refresh: If True, ignore cache and recompute (but still cache result).
+            _cache_skip: If True, skip cache entirely (don't read or write).
+            **kwargs: Keyword arguments for the wrapped function.
+
+        Returns:
+            The function result (DataFrame).
+        """
+        if _cache_skip:
+            return self._func(*args, **kwargs)
+
+        cache_key = _generate_cache_key(self._key_prefix, self._func, args, kwargs, self._key_fn)
+
+        # Check cache unless refreshing
+        if not _cache_refresh:
+            cached = get_cached_dataframe(self._url, cache_key, format=self._format)
+            if cached is not None:
+                return cached
+
+        # Compute result
+        result = self._func(*args, **kwargs)
+
+        # Cache the result
+        cache_dataframe(
+            result,
+            self._url,
+            cache_key,
+            format=self._format,
+            compression=self._compression,
+            ttl=self._ttl,
+            chunk_size_mb=self._chunk_size_mb,
+        )
+
+        return result
+
+    def invalidate(self, *args, **kwargs) -> bool:
+        """Invalidate the cache for specific arguments.
+
+        Args:
+            *args: Positional arguments that were used.
+            **kwargs: Keyword arguments that were used.
+
+        Returns:
+            True if the cache entry was deleted, False if it didn't exist.
+        """
+        cache_key = _generate_cache_key(self._key_prefix, self._func, args, kwargs, self._key_fn)
+        return delete_cached(self._url, cache_key)
+
+    def is_cached(self, *args, **kwargs) -> bool:
+        """Check if a result is cached for specific arguments.
+
+        Args:
+            *args: Positional arguments to check.
+            **kwargs: Keyword arguments to check.
+
+        Returns:
+            True if a cached result exists.
+        """
+        cache_key = _generate_cache_key(self._key_prefix, self._func, args, kwargs, self._key_fn)
+        return cache_exists(self._url, cache_key)
+
+    def cache_key_for(self, *args, **kwargs) -> str:
+        """Get the cache key that would be used for specific arguments.
+
+        Useful for debugging or manual cache management.
+
+        Args:
+            *args: Positional arguments.
+            **kwargs: Keyword arguments.
+
+        Returns:
+            The cache key string.
+        """
+        return _generate_cache_key(self._key_prefix, self._func, args, kwargs, self._key_fn)
+
+
+class CachedLazyFunction:
+    """Wrapper for a cached function that returns LazyFrame."""
+
+    def __init__(
+        self,
+        func: Callable[..., pl.LazyFrame],
+        url: str,
+        ttl: int | None = None,
+        key_prefix: str = "polars_redis:cache",
+        key_fn: Callable[..., str] | None = None,
+        format: Literal["ipc", "parquet"] = "ipc",
+        compression: str | None = None,
+        chunk_size_mb: int | None = None,
+    ):
+        self._func = func
+        self._url = url
+        self._ttl = ttl
+        self._key_prefix = key_prefix
+        self._key_fn = key_fn
+        self._format = format
+        self._compression = compression
+        self._chunk_size_mb = chunk_size_mb
+
+        functools.update_wrapper(self, func)
+
+    def __call__(
+        self,
+        *args,
+        _cache_refresh: bool = False,
+        _cache_skip: bool = False,
+        **kwargs,
+    ) -> pl.LazyFrame:
+        """Call the function, using cache if available.
+
+        The LazyFrame is collected before caching. On cache hit, returns
+        a LazyFrame wrapping the cached DataFrame.
+
+        Args:
+            *args: Positional arguments for the wrapped function.
+            _cache_refresh: If True, ignore cache and recompute.
+            _cache_skip: If True, skip cache entirely.
+            **kwargs: Keyword arguments for the wrapped function.
+
+        Returns:
+            The function result (LazyFrame).
+        """
+        if _cache_skip:
+            return self._func(*args, **kwargs)
+
+        cache_key = _generate_cache_key(self._key_prefix, self._func, args, kwargs, self._key_fn)
+
+        # Check cache unless refreshing
+        if not _cache_refresh:
+            cached = get_cached_dataframe(self._url, cache_key, format=self._format)
+            if cached is not None:
+                return cached.lazy()
+
+        # Compute result - collect the LazyFrame
+        lazy_result = self._func(*args, **kwargs)
+        result = lazy_result.collect()
+
+        # Cache the collected result
+        cache_dataframe(
+            result,
+            self._url,
+            cache_key,
+            format=self._format,
+            compression=self._compression,
+            ttl=self._ttl,
+            chunk_size_mb=self._chunk_size_mb,
+        )
+
+        return result.lazy()
+
+    def invalidate(self, *args, **kwargs) -> bool:
+        """Invalidate the cache for specific arguments."""
+        cache_key = _generate_cache_key(self._key_prefix, self._func, args, kwargs, self._key_fn)
+        return delete_cached(self._url, cache_key)
+
+    def is_cached(self, *args, **kwargs) -> bool:
+        """Check if a result is cached for specific arguments."""
+        cache_key = _generate_cache_key(self._key_prefix, self._func, args, kwargs, self._key_fn)
+        return cache_exists(self._url, cache_key)
+
+    def cache_key_for(self, *args, **kwargs) -> str:
+        """Get the cache key that would be used for specific arguments."""
+        return _generate_cache_key(self._key_prefix, self._func, args, kwargs, self._key_fn)
+
+
+def cache(
+    url: str,
+    *,
+    ttl: int | None = None,
+    key_prefix: str = "polars_redis:cache",
+    key_fn: Callable[..., str] | None = None,
+    format: Literal["ipc", "parquet"] = "ipc",
+    compression: str | None = None,
+    chunk_size_mb: int | None = None,
+) -> Callable[[F], CachedFunction]:
+    """Decorator to cache DataFrame-returning function results in Redis.
+
+    Args:
+        url: Redis connection URL (e.g., "redis://localhost:6379").
+        ttl: Time-to-live in seconds. If None, cache never expires.
+        key_prefix: Prefix for all cache keys.
+        key_fn: Custom function to generate cache key from arguments.
+            If None, key is generated from function name and argument hash.
+        format: Serialization format ("ipc" or "parquet").
+        compression: Compression codec (e.g., "lz4", "zstd").
+        chunk_size_mb: Chunk size for large DataFrames. Set to 0 to disable.
+
+    Returns:
+        A decorator that wraps the function with caching.
+
+    Example:
+        >>> import polars as pl
+        >>> import polars_redis as redis
+        >>>
+        >>> @redis.cache(url="redis://localhost", ttl=3600)
+        ... def expensive_transform(start: str, end: str) -> pl.DataFrame:
+        ...     # Complex computation...
+        ...     return df
+        >>>
+        >>> # First call: computes and caches
+        >>> result = expensive_transform("2024-01-01", "2024-12-31")
+        >>>
+        >>> # Second call: returns from cache
+        >>> result = expensive_transform("2024-01-01", "2024-12-31")
+        >>>
+        >>> # Force refresh
+        >>> result = expensive_transform("2024-01-01", "2024-12-31", _cache_refresh=True)
+        >>>
+        >>> # Invalidate cache for specific args
+        >>> expensive_transform.invalidate("2024-01-01", "2024-12-31")
+    """
+
+    def decorator(func: F) -> CachedFunction:
+        return CachedFunction(
+            func,
+            url=url,
+            ttl=ttl,
+            key_prefix=key_prefix,
+            key_fn=key_fn,
+            format=format,
+            compression=compression,
+            chunk_size_mb=chunk_size_mb,
+        )
+
+    return decorator
+
+
+def cache_lazy(
+    url: str,
+    *,
+    ttl: int | None = None,
+    key_prefix: str = "polars_redis:cache",
+    key_fn: Callable[..., str] | None = None,
+    format: Literal["ipc", "parquet"] = "ipc",
+    compression: str | None = None,
+    chunk_size_mb: int | None = None,
+) -> Callable[[LF], CachedLazyFunction]:
+    """Decorator to cache LazyFrame-returning function results in Redis.
+
+    The LazyFrame is collected before caching. On cache hit, returns
+    a LazyFrame wrapping the cached DataFrame.
+
+    Args:
+        url: Redis connection URL (e.g., "redis://localhost:6379").
+        ttl: Time-to-live in seconds. If None, cache never expires.
+        key_prefix: Prefix for all cache keys.
+        key_fn: Custom function to generate cache key from arguments.
+        format: Serialization format ("ipc" or "parquet").
+        compression: Compression codec (e.g., "lz4", "zstd").
+        chunk_size_mb: Chunk size for large DataFrames.
+
+    Returns:
+        A decorator that wraps the function with caching.
+
+    Example:
+        >>> import polars as pl
+        >>> import polars_redis as redis
+        >>>
+        >>> @redis.cache_lazy(url="redis://localhost", ttl=3600)
+        ... def build_pipeline(config: dict) -> pl.LazyFrame:
+        ...     return pl.scan_parquet("data.parquet").filter(...)
+        >>>
+        >>> # First call: executes pipeline and caches result
+        >>> lf = build_pipeline({"filter": "active"})
+        >>> df = lf.collect()  # Already collected internally
+        >>>
+        >>> # Second call: returns cached result as LazyFrame
+        >>> lf = build_pipeline({"filter": "active"})
+    """
+
+    def decorator(func: LF) -> CachedLazyFunction:
+        return CachedLazyFunction(
+            func,
+            url=url,
+            ttl=ttl,
+            key_prefix=key_prefix,
+            key_fn=key_fn,
+            format=format,
+            compression=compression,
+            chunk_size_mb=chunk_size_mb,
+        )
+
+    return decorator

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,0 +1,448 @@
+"""Tests for DataFrame caching decorator."""
+
+import polars as pl
+import polars_redis as redis
+import pytest
+from polars.testing import assert_frame_equal
+
+REDIS_URL = "redis://localhost:6379"
+
+
+@pytest.fixture(autouse=True)
+def cleanup():
+    """Clean up test cache keys before and after each test."""
+    # Keys are auto-generated, so we clean by pattern
+    # For now, we rely on TTL or manual cleanup in tests
+    yield
+
+
+class TestCacheDecorator:
+    """Tests for the @cache decorator."""
+
+    def test_basic_caching(self):
+        """Test that function results are cached."""
+        call_count = 0
+
+        @redis.cache(url=REDIS_URL, ttl=60, key_prefix="test:decorator")
+        def compute(x: int) -> pl.DataFrame:
+            nonlocal call_count
+            call_count += 1
+            return pl.DataFrame({"value": [x * 2]})
+
+        # First call - should compute
+        result1 = compute(5)
+        assert call_count == 1
+        assert result1["value"][0] == 10
+
+        # Second call with same args - should use cache
+        result2 = compute(5)
+        assert call_count == 1  # Not incremented
+        assert_frame_equal(result1, result2)
+
+        # Different args - should compute again
+        result3 = compute(10)
+        assert call_count == 2
+        assert result3["value"][0] == 20
+
+        # Clean up
+        compute.invalidate(5)
+        compute.invalidate(10)
+
+    def test_cache_refresh(self):
+        """Test _cache_refresh forces recomputation."""
+        call_count = 0
+
+        @redis.cache(url=REDIS_URL, ttl=60, key_prefix="test:decorator:refresh")
+        def compute(x: int) -> pl.DataFrame:
+            nonlocal call_count
+            call_count += 1
+            return pl.DataFrame({"value": [x], "call": [call_count]})
+
+        # First call
+        result1 = compute(1)
+        assert call_count == 1
+
+        # Cached call
+        result2 = compute(1)
+        assert call_count == 1
+        assert result2["call"][0] == 1
+
+        # Force refresh
+        result3 = compute(1, _cache_refresh=True)
+        assert call_count == 2
+        assert result3["call"][0] == 2
+
+        # Clean up
+        compute.invalidate(1)
+
+    def test_cache_skip(self):
+        """Test _cache_skip bypasses cache entirely."""
+        call_count = 0
+
+        @redis.cache(url=REDIS_URL, ttl=60, key_prefix="test:decorator:skip")
+        def compute(x: int) -> pl.DataFrame:
+            nonlocal call_count
+            call_count += 1
+            return pl.DataFrame({"value": [x]})
+
+        # First call with skip - should not cache
+        result1 = compute(1, _cache_skip=True)
+        assert call_count == 1
+
+        # Second call with skip - should compute again
+        result2 = compute(1, _cache_skip=True)
+        assert call_count == 2
+
+        # Normal call - should also compute (nothing was cached)
+        result3 = compute(1)
+        assert call_count == 3
+
+        # Now it's cached
+        result4 = compute(1)
+        assert call_count == 3
+
+        # Clean up
+        compute.invalidate(1)
+
+    def test_invalidate(self):
+        """Test cache invalidation."""
+        call_count = 0
+
+        @redis.cache(url=REDIS_URL, ttl=60, key_prefix="test:decorator:invalidate")
+        def compute(x: int) -> pl.DataFrame:
+            nonlocal call_count
+            call_count += 1
+            return pl.DataFrame({"value": [x]})
+
+        # Cache a result
+        compute(1)
+        assert call_count == 1
+
+        # Verify it's cached
+        assert compute.is_cached(1)
+
+        # Invalidate
+        deleted = compute.invalidate(1)
+        assert deleted is True
+
+        # Verify it's gone
+        assert not compute.is_cached(1)
+
+        # Next call should recompute
+        compute(1)
+        assert call_count == 2
+
+        # Clean up
+        compute.invalidate(1)
+
+    def test_is_cached(self):
+        """Test is_cached method."""
+
+        @redis.cache(url=REDIS_URL, ttl=60, key_prefix="test:decorator:is_cached")
+        def compute(x: int) -> pl.DataFrame:
+            return pl.DataFrame({"value": [x]})
+
+        # Not cached initially
+        assert not compute.is_cached(42)
+
+        # Cache it
+        compute(42)
+
+        # Now it's cached
+        assert compute.is_cached(42)
+
+        # Different args are not cached
+        assert not compute.is_cached(43)
+
+        # Clean up
+        compute.invalidate(42)
+
+    def test_cache_key_for(self):
+        """Test cache_key_for method."""
+
+        @redis.cache(url=REDIS_URL, key_prefix="test:decorator:key")
+        def compute(x: int, y: str) -> pl.DataFrame:
+            return pl.DataFrame({"value": [x]})
+
+        key = compute.cache_key_for(1, "a")
+        assert key.startswith("test:decorator:key:")
+        assert "compute" in key
+
+        # Same args should give same key
+        key2 = compute.cache_key_for(1, "a")
+        assert key == key2
+
+        # Different args should give different key
+        key3 = compute.cache_key_for(1, "b")
+        assert key != key3
+
+    def test_custom_key_fn(self):
+        """Test custom key function."""
+        call_count = 0
+
+        @redis.cache(
+            url=REDIS_URL,
+            ttl=60,
+            key_prefix="test:decorator:custom_key",
+            key_fn=lambda start, end: f"{start}_{end}",
+        )
+        def compute(start: str, end: str) -> pl.DataFrame:
+            nonlocal call_count
+            call_count += 1
+            return pl.DataFrame({"start": [start], "end": [end]})
+
+        # Check key format
+        key = compute.cache_key_for("2024-01-01", "2024-12-31")
+        assert "2024-01-01_2024-12-31" in key
+
+        # Verify caching works
+        compute("2024-01-01", "2024-12-31")
+        assert call_count == 1
+
+        compute("2024-01-01", "2024-12-31")
+        assert call_count == 1  # Cached
+
+        # Clean up
+        compute.invalidate("2024-01-01", "2024-12-31")
+
+    def test_multiple_args(self):
+        """Test caching with multiple argument types."""
+
+        @redis.cache(url=REDIS_URL, ttl=60, key_prefix="test:decorator:multi_args")
+        def compute(a: int, b: str, c: list, d: dict) -> pl.DataFrame:
+            return pl.DataFrame({"a": [a], "b": [b]})
+
+        # Cache with complex args
+        result1 = compute(1, "hello", [1, 2, 3], {"key": "value"})
+
+        # Same args should hit cache
+        result2 = compute(1, "hello", [1, 2, 3], {"key": "value"})
+        assert_frame_equal(result1, result2)
+
+        # Different args should miss
+        result3 = compute(1, "hello", [1, 2, 4], {"key": "value"})  # Different list
+
+        # Clean up
+        compute.invalidate(1, "hello", [1, 2, 3], {"key": "value"})
+        compute.invalidate(1, "hello", [1, 2, 4], {"key": "value"})
+
+    def test_kwargs(self):
+        """Test caching with keyword arguments."""
+        call_count = 0
+
+        @redis.cache(url=REDIS_URL, ttl=60, key_prefix="test:decorator:kwargs")
+        def compute(x: int, multiplier: int = 2) -> pl.DataFrame:
+            nonlocal call_count
+            call_count += 1
+            return pl.DataFrame({"value": [x * multiplier]})
+
+        # Positional and keyword should be equivalent
+        result1 = compute(5, multiplier=2)
+        assert call_count == 1
+
+        result2 = compute(5)  # Uses default
+        assert call_count == 1  # Should hit cache
+
+        # Different kwarg value
+        result3 = compute(5, multiplier=3)
+        assert call_count == 2
+
+        # Clean up
+        compute.invalidate(5, multiplier=2)
+        compute.invalidate(5, multiplier=3)
+
+    def test_compression(self):
+        """Test caching with compression."""
+
+        @redis.cache(
+            url=REDIS_URL,
+            ttl=60,
+            key_prefix="test:decorator:compression",
+            compression="zstd",
+        )
+        def compute(x: int) -> pl.DataFrame:
+            return pl.DataFrame({"value": list(range(x))})
+
+        result1 = compute(100)
+        result2 = compute(100)
+        assert_frame_equal(result1, result2)
+
+        # Clean up
+        compute.invalidate(100)
+
+    def test_parquet_format(self):
+        """Test caching with Parquet format."""
+
+        @redis.cache(
+            url=REDIS_URL,
+            ttl=60,
+            key_prefix="test:decorator:parquet",
+            format="parquet",
+        )
+        def compute(x: int) -> pl.DataFrame:
+            return pl.DataFrame({"value": list(range(x))})
+
+        result1 = compute(50)
+        result2 = compute(50)
+        assert_frame_equal(result1, result2)
+
+        # Clean up
+        compute.invalidate(50)
+
+
+class TestCacheLazyDecorator:
+    """Tests for the @cache_lazy decorator."""
+
+    def test_basic_lazy_caching(self):
+        """Test that LazyFrame results are cached."""
+        call_count = 0
+
+        @redis.cache_lazy(url=REDIS_URL, ttl=60, key_prefix="test:lazy")
+        def build_pipeline(x: int) -> pl.LazyFrame:
+            nonlocal call_count
+            call_count += 1
+            return pl.DataFrame({"value": [x * 2]}).lazy()
+
+        # First call - should compute
+        lf1 = build_pipeline(5)
+        assert call_count == 1
+        assert isinstance(lf1, pl.LazyFrame)
+        df1 = lf1.collect()
+        assert df1["value"][0] == 10
+
+        # Second call - should use cache
+        lf2 = build_pipeline(5)
+        assert call_count == 1  # Not incremented
+        df2 = lf2.collect()
+        assert_frame_equal(df1, df2)
+
+        # Clean up
+        build_pipeline.invalidate(5)
+
+    def test_lazy_refresh(self):
+        """Test _cache_refresh with LazyFrame."""
+        call_count = 0
+
+        @redis.cache_lazy(url=REDIS_URL, ttl=60, key_prefix="test:lazy:refresh")
+        def build_pipeline(x: int) -> pl.LazyFrame:
+            nonlocal call_count
+            call_count += 1
+            return pl.DataFrame({"value": [x], "call": [call_count]}).lazy()
+
+        # First call
+        lf1 = build_pipeline(1)
+        assert call_count == 1
+
+        # Cached call
+        lf2 = build_pipeline(1)
+        assert call_count == 1
+
+        # Force refresh
+        lf3 = build_pipeline(1, _cache_refresh=True)
+        assert call_count == 2
+        df3 = lf3.collect()
+        assert df3["call"][0] == 2
+
+        # Clean up
+        build_pipeline.invalidate(1)
+
+    def test_lazy_skip(self):
+        """Test _cache_skip with LazyFrame."""
+        call_count = 0
+
+        @redis.cache_lazy(url=REDIS_URL, ttl=60, key_prefix="test:lazy:skip")
+        def build_pipeline(x: int) -> pl.LazyFrame:
+            nonlocal call_count
+            call_count += 1
+            return pl.DataFrame({"value": [x]}).lazy()
+
+        # Skip cache
+        lf1 = build_pipeline(1, _cache_skip=True)
+        assert call_count == 1
+
+        # Skip again
+        lf2 = build_pipeline(1, _cache_skip=True)
+        assert call_count == 2
+
+    def test_lazy_invalidate(self):
+        """Test cache invalidation for LazyFrame."""
+
+        @redis.cache_lazy(url=REDIS_URL, ttl=60, key_prefix="test:lazy:invalidate")
+        def build_pipeline(x: int) -> pl.LazyFrame:
+            return pl.DataFrame({"value": [x]}).lazy()
+
+        # Cache a result
+        build_pipeline(1)
+        assert build_pipeline.is_cached(1)
+
+        # Invalidate
+        build_pipeline.invalidate(1)
+        assert not build_pipeline.is_cached(1)
+
+
+class TestEdgeCases:
+    """Tests for edge cases and error handling."""
+
+    def test_empty_dataframe(self):
+        """Test caching empty DataFrames."""
+
+        @redis.cache(url=REDIS_URL, ttl=60, key_prefix="test:empty")
+        def compute() -> pl.DataFrame:
+            return pl.DataFrame({"a": [], "b": []}).cast({"a": pl.Int64, "b": pl.Utf8})
+
+        result1 = compute()
+        result2 = compute()
+        assert_frame_equal(result1, result2)
+        assert len(result1) == 0
+
+        # Clean up
+        compute.invalidate()
+
+    def test_large_dataframe(self):
+        """Test caching larger DataFrames (triggers chunking)."""
+
+        @redis.cache(
+            url=REDIS_URL,
+            ttl=60,
+            key_prefix="test:large",
+            chunk_size_mb=0.001,  # Force chunking with tiny chunks
+        )
+        def compute(n: int) -> pl.DataFrame:
+            return pl.DataFrame(
+                {
+                    "id": list(range(n)),
+                    "data": [f"row_{i}" for i in range(n)],
+                }
+            )
+
+        result1 = compute(1000)
+        result2 = compute(1000)
+        assert_frame_equal(result1, result2)
+
+        # Clean up
+        compute.invalidate(1000)
+
+    def test_function_metadata_preserved(self):
+        """Test that function metadata is preserved."""
+
+        @redis.cache(url=REDIS_URL, key_prefix="test:meta")
+        def my_function(x: int) -> pl.DataFrame:
+            """This is my docstring."""
+            return pl.DataFrame({"value": [x]})
+
+        assert my_function.__name__ == "my_function"
+        assert "docstring" in my_function.__doc__
+
+    def test_none_args(self):
+        """Test caching with None arguments."""
+
+        @redis.cache(url=REDIS_URL, ttl=60, key_prefix="test:none")
+        def compute(x: int | None) -> pl.DataFrame:
+            return pl.DataFrame({"value": [x if x else 0]})
+
+        result1 = compute(None)
+        result2 = compute(None)
+        assert_frame_equal(result1, result2)
+
+        # Clean up
+        compute.invalidate(None)


### PR DESCRIPTION
Closes #119

## Summary

Add decorators that automatically cache function results (DataFrames) in Redis, similar to `functools.lru_cache` but distributed.

## Features

### `@cache` decorator for DataFrame-returning functions
```python
@redis.cache(url="redis://localhost", ttl=3600)
def expensive_transform(start: str, end: str) -> pl.DataFrame:
    # Complex computation...
    return df

# First call: computes and caches
result = expensive_transform("2024-01-01", "2024-12-31")

# Second call: returns from cache
result = expensive_transform("2024-01-01", "2024-12-31")
```

### `@cache_lazy` decorator for LazyFrame-returning functions
```python
@redis.cache_lazy(url="redis://localhost", ttl=3600)
def build_pipeline(config: dict) -> pl.LazyFrame:
    return pl.scan_parquet("data.parquet").filter(...)
```

### Cache control
- `_cache_refresh=True`: Force recomputation
- `_cache_skip=True`: Bypass cache entirely
- `func.invalidate(*args)`: Invalidate specific cached result
- `func.is_cached(*args)`: Check if result is cached
- `func.cache_key_for(*args)`: Get cache key for debugging

### Configuration options
- `ttl`: Time-to-live in seconds
- `key_prefix`: Custom key prefix
- `key_fn`: Custom key generation function
- `format`: Serialization format (ipc/parquet)
- `compression`: Compression codec
- `chunk_size_mb`: Chunk size for large DataFrames

## Tests

19 tests covering:
- Basic caching behavior
- Cache refresh and skip
- Invalidation
- Custom key functions
- Multiple argument types
- Compression and format options
- LazyFrame support
- Edge cases (empty DataFrames, large DataFrames, None args)