### PR TITLE
feat: add Redis Streams streaming source (#120)

### DIFF
--- a/docs/guide/streams.md
+++ b/docs/guide/streams.md
@@ -1,0 +1,361 @@
+# Redis Streams Consumption
+
+polars-redis provides functions for consuming Redis Streams as streaming data sources with support for consumer groups, blocking reads, and continuous batch iteration.
+
+## Overview
+
+Redis Streams are append-only log data structures ideal for:
+
+- Event sourcing and CDC (Change Data Capture)
+- Real-time analytics pipelines
+- IoT sensor data ingestion
+- Log aggregation
+- Message queuing with acknowledgment
+
+**Key Features:**
+
+- Single stream consumption with `read_stream()` and `scan_stream()`
+- Consumer group support for distributed processing
+- Blocking reads for real-time tailing
+- Batch iteration with `iter_stream()` and `stream_batches()`
+- Manual or automatic message acknowledgment
+
+## Differences from `scan_streams`/`read_streams`
+
+The existing `scan_streams()` and `read_streams()` functions scan **multiple streams** by key pattern. The new functions in this module focus on:
+
+1. **Single stream consumption** - Work with one stream at a time
+2. **Consumer groups** - Distributed message processing with XREADGROUP
+3. **Blocking reads** - Real-time tailing of new entries
+4. **Continuous streaming** - Batch iterators for ongoing processing
+
+## Basic Usage
+
+### Reading Stream Entries
+
+Use `read_stream()` to read entries from a single stream:
+
+```python
+import polars as pl
+import polars_redis as redis
+
+# Read all entries from a stream
+df = redis.read_stream(
+    "redis://localhost",
+    stream="events",
+    schema={"user_id": pl.Utf8, "action": pl.Utf8, "value": pl.Int64},
+)
+
+print(df)
+# shape: (100, 5)
+# +-------------------+-------------+---------+--------+-------+
+# | _id               | _ts         | user_id | action | value |
+# | ---               | ---         | ---     | ---    | ---   |
+# | str               | i64         | str     | str    | i64   |
+# +-------------------+-------------+---------+--------+-------+
+# | 1704067200000-0   | 17040672... | user_1  | click  | 10    |
+# | 1704067200001-0   | 17040672... | user_2  | view   | 20    |
+# +-------------------+-------------+---------+--------+-------+
+```
+
+### Entry ID Parsing
+
+Stream entry IDs contain timestamp and sequence information:
+
+- `_id`: Full entry ID (e.g., "1704067200000-0")
+- `_ts`: Timestamp in milliseconds (first part of ID)
+- `_seq`: Sequence number (second part of ID, optional)
+
+```python
+df = redis.read_stream(
+    "redis://localhost",
+    stream="events",
+    include_id=True,
+    include_timestamp=True,
+    include_sequence=True,  # Enable sequence column
+)
+```
+
+### Reading with Count Limit
+
+```python
+# Read only the first 100 entries
+df = redis.read_stream(
+    "redis://localhost",
+    stream="events",
+    count=100,
+)
+```
+
+### Reading an ID Range
+
+```python
+# Read entries between specific IDs
+df = redis.read_stream(
+    "redis://localhost",
+    stream="events",
+    start_id="1704067200000-0",
+    end_id="1704067300000-0",
+)
+
+# Read from oldest to newest (default)
+df = redis.read_stream(url, stream="events", start_id="-", end_id="+")
+```
+
+## Consumer Groups
+
+Consumer groups enable distributed stream processing where multiple consumers share the workload.
+
+### Basic Consumer Group Usage
+
+```python
+# Read as part of a consumer group
+df = redis.read_stream(
+    "redis://localhost",
+    stream="events",
+    group="analytics",
+    consumer="worker-1",
+    auto_ack=True,  # Automatically acknowledge messages
+)
+```
+
+### Manual Acknowledgment
+
+For at-least-once processing, disable auto-ack and acknowledge after successful processing:
+
+```python
+# Read without auto-acknowledgment
+df = redis.read_stream(
+    "redis://localhost",
+    stream="events",
+    group="analytics",
+    consumer="worker-1",
+    auto_ack=False,
+)
+
+# Process entries
+try:
+    process(df)
+    
+    # Acknowledge after successful processing
+    entry_ids = df["_id"].to_list()
+    redis.ack_entries("redis://localhost", "events", "analytics", entry_ids)
+except Exception as e:
+    # Messages will be redelivered to another consumer
+    log_error(e)
+```
+
+### Multiple Consumers
+
+Distribute work across multiple consumers:
+
+```python
+# Worker 1
+df1 = redis.read_stream(
+    url, stream="events",
+    group="analytics",
+    consumer="worker-1",
+    count=100,
+    auto_ack=True,
+)
+
+# Worker 2 (in another process)
+df2 = redis.read_stream(
+    url, stream="events",
+    group="analytics",
+    consumer="worker-2",
+    count=100,
+    auto_ack=True,
+)
+
+# Each worker receives different entries
+```
+
+## Blocking Reads
+
+Block waiting for new entries in real-time:
+
+```python
+# Wait up to 5 seconds for new entries
+df = redis.read_stream(
+    "redis://localhost",
+    stream="events",
+    start_id="$",  # Only new entries (after current latest)
+    block_ms=5000,
+    count=100,
+)
+```
+
+## Batch Iteration
+
+For continuous stream processing, use iterators that yield DataFrames.
+
+### Synchronous Iterator
+
+```python
+for batch_df in redis.iter_stream(
+    "redis://localhost",
+    stream="events",
+    batch_size=100,
+    block_ms=1000,  # Wait up to 1 second for batch
+):
+    # Process each batch
+    summary = batch_df.group_by("action").len()
+    print(f"Batch: {len(batch_df)} entries")
+    
+    if should_stop():
+        break
+```
+
+### With Consumer Group
+
+```python
+for batch_df in redis.iter_stream(
+    "redis://localhost",
+    stream="events",
+    group="analytics",
+    consumer="worker-1",
+    batch_size=100,
+    auto_ack=True,
+):
+    process_batch(batch_df)
+```
+
+### Async Iterator
+
+```python
+import asyncio
+
+async def process_stream():
+    async for batch_df in redis.stream_batches(
+        "redis://localhost",
+        stream="events",
+        batch_size=100,
+        batch_timeout_ms=1000,
+    ):
+        await process_async(batch_df)
+        
+        if should_stop():
+            break
+
+asyncio.run(process_stream())
+```
+
+## Lazy Scanning
+
+Use `scan_stream()` for lazy evaluation:
+
+```python
+# Create LazyFrame (no execution yet)
+lf = redis.scan_stream(
+    "redis://localhost",
+    stream="events",
+    schema={"action": pl.Utf8, "value": pl.Float64},
+)
+
+# Apply lazy operations
+result = (
+    lf.filter(pl.col("value") > 100)
+    .group_by("action")
+    .agg(pl.col("value").mean())
+    .collect()
+)
+```
+
+Note: Consumer groups and blocking reads are not supported in lazy mode.
+
+## Real-Time Analytics Example
+
+```python
+import polars as pl
+import polars_redis as redis
+
+# Continuous aggregation over stream
+for batch_df in redis.iter_stream(
+    "redis://localhost",
+    stream="metrics",
+    group="aggregator",
+    consumer="worker-1",
+    batch_size=1000,
+    block_ms=5000,
+    schema={
+        "sensor_id": pl.Utf8,
+        "value": pl.Float64,
+    },
+    auto_ack=True,
+):
+    # Aggregate by sensor
+    summary = (
+        batch_df.group_by("sensor_id")
+        .agg([
+            pl.col("value").mean().alias("avg"),
+            pl.col("value").max().alias("max"),
+            pl.len().alias("count"),
+        ])
+    )
+    
+    # Store aggregates
+    redis.write_hashes(
+        "redis://localhost",
+        summary,
+        key_column="sensor_id",
+        key_prefix="sensor:stats:",
+    )
+```
+
+## API Reference
+
+### `read_stream()`
+
+Read entries from a Redis Stream into a DataFrame.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `url` | `str` | required | Redis connection URL |
+| `stream` | `str` | required | Stream name |
+| `schema` | `dict` | `None` | Field name to dtype mapping |
+| `start_id` | `str` | `"-"` | Start entry ID |
+| `end_id` | `str` | `"+"` | End entry ID |
+| `count` | `int` | `None` | Max entries to read |
+| `block_ms` | `int` | `None` | Block timeout (ms) |
+| `group` | `str` | `None` | Consumer group name |
+| `consumer` | `str` | `None` | Consumer name |
+| `auto_ack` | `bool` | `False` | Auto-acknowledge messages |
+| `create_group` | `bool` | `True` | Create group if missing |
+
+### `scan_stream()`
+
+Lazy version of `read_stream()`. Returns a LazyFrame.
+
+### `iter_stream()`
+
+Synchronous iterator yielding DataFrame batches.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `batch_size` | `int` | `100` | Max entries per batch |
+| `block_ms` | `int` | `1000` | Block timeout per batch |
+| *(plus all `read_stream` params)* | | | |
+
+### `stream_batches()`
+
+Async iterator yielding DataFrame batches.
+
+Same parameters as `iter_stream()`.
+
+### `ack_entries()`
+
+Acknowledge stream entries in a consumer group.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `url` | `str` | Redis connection URL |
+| `stream` | `str` | Stream name |
+| `group` | `str` | Consumer group name |
+| `entry_ids` | `list[str]` | Entry IDs to acknowledge |
+
+## See Also
+
+- [Scanning Data](scanning.md) - Multi-stream scanning with `scan_streams()`
+- [Pub/Sub Streaming](pubsub.md) - Real-time Pub/Sub messaging
+- [Writing Data](writing.md) - Write DataFrames to Redis

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ nav:
       - Writing Data: guide/writing.md
       - DataFrame Caching: guide/caching.md
       - Pub/Sub Streaming: guide/pubsub.md
+      - Streams Consumption: guide/streams.md
       - Schema Inference: guide/schema-inference.md
       - Configuration: guide/configuration.md
       - Performance: guide/performance.md

--- a/python/polars_redis/__init__.py
+++ b/python/polars_redis/__init__.py
@@ -89,6 +89,13 @@ from polars_redis._search import (
     search_hashes,
     search_json,
 )
+from polars_redis._streams import (
+    ack_entries,
+    iter_stream,
+    read_stream,
+    scan_stream,
+    stream_batches,
+)
 from polars_redis._write import (
     WriteResult,
     write_hashes,
@@ -195,6 +202,12 @@ __all__ = [
     "collect_pubsub",
     "subscribe_batches",
     "iter_batches",
+    # Stream consumption (single stream with consumer groups)
+    "read_stream",
+    "scan_stream",
+    "iter_stream",
+    "stream_batches",
+    "ack_entries",
     # Environment defaults
     "get_default_batch_size",
     "get_default_count_hint",

--- a/python/polars_redis/_streams.py
+++ b/python/polars_redis/_streams.py
@@ -1,0 +1,675 @@
+"""Redis Streams streaming support for real-time DataFrame processing.
+
+This module provides functions for consuming Redis Streams as streaming data sources,
+with support for consumer groups, blocking reads, and continuous batch iteration.
+
+Note: This module differs from _scan.py's scan_streams/read_streams which scan
+multiple streams by pattern. This module focuses on single-stream consumption
+with consumer group support and real-time tailing.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import AsyncIterator, Iterator
+from typing import Any, Literal
+
+import polars as pl
+
+
+def read_stream(
+    url: str,
+    stream: str,
+    *,
+    schema: dict[str, pl.DataType] | None = None,
+    start_id: str = "-",
+    end_id: str = "+",
+    count: int | None = None,
+    block_ms: int | None = None,
+    group: str | None = None,
+    consumer: str | None = None,
+    auto_ack: bool = False,
+    create_group: bool = True,
+    include_id: bool = True,
+    id_column: str = "_id",
+    include_timestamp: bool = True,
+    timestamp_column: str = "_ts",
+    include_sequence: bool = False,
+    sequence_column: str = "_seq",
+) -> pl.DataFrame:
+    """Read entries from a Redis Stream into a DataFrame.
+
+    This function reads entries from a single Redis Stream with support for
+    consumer groups and blocking reads.
+
+    Args:
+        url: Redis connection URL (e.g., "redis://localhost:6379").
+        stream: Name of the stream to read from.
+        schema: Dictionary mapping field names to Polars dtypes.
+        start_id: Start entry ID ("-" = oldest, "$" = only new entries).
+        end_id: End entry ID ("+" = newest). Only used with XRANGE.
+        count: Maximum number of entries to read.
+        block_ms: Block for new entries (milliseconds). Only works with XREAD/XREADGROUP.
+        group: Consumer group name. If provided, uses XREADGROUP.
+        consumer: Consumer name within the group. Required if group is set.
+        auto_ack: Automatically acknowledge messages after reading.
+        create_group: Create the consumer group if it doesn't exist.
+        include_id: Include the entry ID as a column.
+        id_column: Name of the ID column.
+        include_timestamp: Include the timestamp (from ID) as a column.
+        timestamp_column: Name of the timestamp column.
+        include_sequence: Include the sequence number (from ID) as a column.
+        sequence_column: Name of the sequence column.
+
+    Returns:
+        DataFrame containing the stream entries.
+
+    Example:
+        >>> import polars_redis as redis
+        >>>
+        >>> # Read all entries from a stream
+        >>> df = redis.read_stream(
+        ...     "redis://localhost",
+        ...     stream="events",
+        ...     schema={"user_id": pl.Utf8, "action": pl.Utf8},
+        ... )
+        >>>
+        >>> # Read with consumer group
+        >>> df = redis.read_stream(
+        ...     "redis://localhost",
+        ...     stream="events",
+        ...     group="analytics",
+        ...     consumer="worker-1",
+        ...     schema={"user_id": pl.Utf8, "action": pl.Utf8},
+        ...     auto_ack=True,
+        ... )
+        >>>
+        >>> # Block for new entries
+        >>> df = redis.read_stream(
+        ...     "redis://localhost",
+        ...     stream="events",
+        ...     start_id="$",  # Only new entries
+        ...     block_ms=5000,  # Wait up to 5 seconds
+        ...     count=100,
+        ... )
+    """
+    import redis as redis_client
+
+    client = redis_client.Redis.from_url(url)
+
+    try:
+        entries = _read_stream_entries(
+            client=client,
+            stream=stream,
+            start_id=start_id,
+            end_id=end_id,
+            count=count,
+            block_ms=block_ms,
+            group=group,
+            consumer=consumer,
+            auto_ack=auto_ack,
+            create_group=create_group,
+        )
+
+        return _entries_to_dataframe(
+            entries=entries,
+            schema=schema,
+            include_id=include_id,
+            id_column=id_column,
+            include_timestamp=include_timestamp,
+            timestamp_column=timestamp_column,
+            include_sequence=include_sequence,
+            sequence_column=sequence_column,
+        )
+    finally:
+        client.close()
+
+
+def scan_stream(
+    url: str,
+    stream: str,
+    *,
+    schema: dict[str, pl.DataType] | None = None,
+    start_id: str = "-",
+    end_id: str = "+",
+    count: int | None = None,
+    include_id: bool = True,
+    id_column: str = "_id",
+    include_timestamp: bool = True,
+    timestamp_column: str = "_ts",
+    include_sequence: bool = False,
+    sequence_column: str = "_seq",
+) -> pl.LazyFrame:
+    """Scan a Redis Stream and return a LazyFrame.
+
+    This is the lazy version of read_stream(). Note that consumer groups
+    and blocking reads are not supported in lazy mode as they require
+    stateful operations.
+
+    Args:
+        url: Redis connection URL.
+        stream: Name of the stream to read from.
+        schema: Dictionary mapping field names to Polars dtypes.
+        start_id: Start entry ID ("-" = oldest).
+        end_id: End entry ID ("+" = newest).
+        count: Maximum number of entries to read.
+        include_id: Include the entry ID as a column.
+        id_column: Name of the ID column.
+        include_timestamp: Include the timestamp (from ID) as a column.
+        timestamp_column: Name of the timestamp column.
+        include_sequence: Include the sequence number (from ID) as a column.
+        sequence_column: Name of the sequence column.
+
+    Returns:
+        LazyFrame for deferred execution.
+
+    Example:
+        >>> import polars_redis as redis
+        >>>
+        >>> lf = redis.scan_stream(
+        ...     "redis://localhost",
+        ...     stream="events",
+        ...     schema={"action": pl.Utf8, "value": pl.Float64},
+        ... )
+        >>> result = lf.group_by("action").agg(pl.col("value").mean()).collect()
+    """
+    df = read_stream(
+        url=url,
+        stream=stream,
+        schema=schema,
+        start_id=start_id,
+        end_id=end_id,
+        count=count,
+        include_id=include_id,
+        id_column=id_column,
+        include_timestamp=include_timestamp,
+        timestamp_column=timestamp_column,
+        include_sequence=include_sequence,
+        sequence_column=sequence_column,
+    )
+    return df.lazy()
+
+
+def iter_stream(
+    url: str,
+    stream: str,
+    *,
+    schema: dict[str, pl.DataType] | None = None,
+    batch_size: int = 100,
+    block_ms: int = 1000,
+    group: str | None = None,
+    consumer: str | None = None,
+    auto_ack: bool = False,
+    create_group: bool = True,
+    start_id: str | None = None,
+    include_id: bool = True,
+    id_column: str = "_id",
+    include_timestamp: bool = True,
+    timestamp_column: str = "_ts",
+    include_sequence: bool = False,
+    sequence_column: str = "_seq",
+) -> Iterator[pl.DataFrame]:
+    """Iterate over stream entries as DataFrame batches.
+
+    Yields DataFrames containing batches of stream entries. This is useful
+    for continuous processing of stream data.
+
+    Args:
+        url: Redis connection URL.
+        stream: Name of the stream to read from.
+        schema: Dictionary mapping field names to Polars dtypes.
+        batch_size: Maximum entries per batch.
+        block_ms: Block time for new entries (milliseconds).
+        group: Consumer group name. If provided, uses XREADGROUP.
+        consumer: Consumer name within the group.
+        auto_ack: Automatically acknowledge messages.
+        create_group: Create the consumer group if it doesn't exist.
+        start_id: Start ID for reading. Defaults to "$" (new only) for
+            non-group reads, ">" (pending) for group reads.
+        include_id: Include the entry ID as a column.
+        id_column: Name of the ID column.
+        include_timestamp: Include the timestamp (from ID) as a column.
+        timestamp_column: Name of the timestamp column.
+        include_sequence: Include the sequence number (from ID) as a column.
+        sequence_column: Name of the sequence column.
+
+    Yields:
+        DataFrames containing batches of stream entries.
+
+    Example:
+        >>> import polars_redis as redis
+        >>>
+        >>> for batch_df in redis.iter_stream(
+        ...     "redis://localhost",
+        ...     stream="events",
+        ...     batch_size=100,
+        ...     block_ms=1000,
+        ... ):
+        ...     print(f"Got {len(batch_df)} entries")
+        ...     process(batch_df)
+        ...     if should_stop():
+        ...         break
+    """
+    import redis as redis_client
+
+    client = redis_client.Redis.from_url(url)
+
+    # Default start_id based on whether using consumer group
+    if start_id is None:
+        start_id = ">" if group else "$"
+
+    # Ensure consumer group exists if specified
+    if group and create_group:
+        _ensure_consumer_group(client, stream, group)
+
+    last_id = start_id
+
+    try:
+        while True:
+            entries = _read_stream_entries(
+                client=client,
+                stream=stream,
+                start_id=last_id,
+                count=batch_size,
+                block_ms=block_ms,
+                group=group,
+                consumer=consumer,
+                auto_ack=auto_ack,
+                create_group=False,  # Already created above
+            )
+
+            if entries:
+                # Update last_id for next iteration (only for non-group reads)
+                if not group:
+                    last_id = entries[-1][0]
+
+                df = _entries_to_dataframe(
+                    entries=entries,
+                    schema=schema,
+                    include_id=include_id,
+                    id_column=id_column,
+                    include_timestamp=include_timestamp,
+                    timestamp_column=timestamp_column,
+                    include_sequence=include_sequence,
+                    sequence_column=sequence_column,
+                )
+
+                yield df
+    finally:
+        client.close()
+
+
+async def stream_batches(
+    url: str,
+    stream: str,
+    *,
+    schema: dict[str, pl.DataType] | None = None,
+    batch_size: int = 100,
+    batch_timeout_ms: int = 1000,
+    group: str | None = None,
+    consumer: str | None = None,
+    auto_ack: bool = False,
+    create_group: bool = True,
+    start_id: str | None = None,
+    include_id: bool = True,
+    id_column: str = "_id",
+    include_timestamp: bool = True,
+    timestamp_column: str = "_ts",
+    include_sequence: bool = False,
+    sequence_column: str = "_seq",
+) -> AsyncIterator[pl.DataFrame]:
+    """Async iterator for stream entries as DataFrame batches.
+
+    Yields DataFrames containing batches of stream entries asynchronously.
+
+    Args:
+        url: Redis connection URL.
+        stream: Name of the stream to read from.
+        schema: Dictionary mapping field names to Polars dtypes.
+        batch_size: Maximum entries per batch.
+        batch_timeout_ms: Timeout for batch collection (milliseconds).
+        group: Consumer group name. If provided, uses XREADGROUP.
+        consumer: Consumer name within the group.
+        auto_ack: Automatically acknowledge messages.
+        create_group: Create the consumer group if it doesn't exist.
+        start_id: Start ID for reading.
+        include_id: Include the entry ID as a column.
+        id_column: Name of the ID column.
+        include_timestamp: Include the timestamp (from ID) as a column.
+        timestamp_column: Name of the timestamp column.
+        include_sequence: Include the sequence number (from ID) as a column.
+        sequence_column: Name of the sequence column.
+
+    Yields:
+        DataFrames containing batches of stream entries.
+
+    Example:
+        >>> import asyncio
+        >>> import polars_redis as redis
+        >>>
+        >>> async def process_events():
+        ...     async for batch_df in redis.stream_batches(
+        ...         "redis://localhost",
+        ...         stream="events",
+        ...         batch_size=100,
+        ...     ):
+        ...         await process_async(batch_df)
+        >>>
+        >>> asyncio.run(process_events())
+    """
+    import redis.asyncio as redis_async
+
+    client = redis_async.Redis.from_url(url)
+
+    # Default start_id based on whether using consumer group
+    if start_id is None:
+        start_id = ">" if group else "$"
+
+    # Ensure consumer group exists if specified
+    if group and create_group:
+        await _ensure_consumer_group_async(client, stream, group)
+
+    last_id = start_id
+
+    try:
+        while True:
+            entries = await _read_stream_entries_async(
+                client=client,
+                stream=stream,
+                start_id=last_id,
+                count=batch_size,
+                block_ms=batch_timeout_ms,
+                group=group,
+                consumer=consumer,
+                auto_ack=auto_ack,
+            )
+
+            if entries:
+                # Update last_id for next iteration (only for non-group reads)
+                if not group:
+                    last_id = entries[-1][0]
+
+                df = _entries_to_dataframe(
+                    entries=entries,
+                    schema=schema,
+                    include_id=include_id,
+                    id_column=id_column,
+                    include_timestamp=include_timestamp,
+                    timestamp_column=timestamp_column,
+                    include_sequence=include_sequence,
+                    sequence_column=sequence_column,
+                )
+
+                yield df
+    finally:
+        await client.aclose()
+
+
+def ack_entries(
+    url: str,
+    stream: str,
+    group: str,
+    entry_ids: list[str],
+) -> int:
+    """Acknowledge stream entries in a consumer group.
+
+    Args:
+        url: Redis connection URL.
+        stream: Name of the stream.
+        group: Consumer group name.
+        entry_ids: List of entry IDs to acknowledge.
+
+    Returns:
+        Number of entries acknowledged.
+
+    Example:
+        >>> import polars_redis as redis
+        >>>
+        >>> # Read without auto-ack
+        >>> df = redis.read_stream(
+        ...     "redis://localhost",
+        ...     stream="events",
+        ...     group="analytics",
+        ...     consumer="worker-1",
+        ...     auto_ack=False,
+        ... )
+        >>>
+        >>> # Process entries...
+        >>> process(df)
+        >>>
+        >>> # Acknowledge after successful processing
+        >>> ids = df["_id"].to_list()
+        >>> redis.ack_entries("redis://localhost", "events", "analytics", ids)
+    """
+    import redis as redis_client
+
+    client = redis_client.Redis.from_url(url)
+    try:
+        return client.xack(stream, group, *entry_ids)
+    finally:
+        client.close()
+
+
+# =============================================================================
+# Internal helper functions
+# =============================================================================
+
+
+def _read_stream_entries(
+    client: Any,
+    stream: str,
+    start_id: str = "-",
+    end_id: str = "+",
+    count: int | None = None,
+    block_ms: int | None = None,
+    group: str | None = None,
+    consumer: str | None = None,
+    auto_ack: bool = False,
+    create_group: bool = True,
+) -> list[tuple[str, dict[str, str]]]:
+    """Read entries from a stream using appropriate Redis command."""
+    entries: list[tuple[str, dict[str, str]]] = []
+
+    if group:
+        # Consumer group mode - use XREADGROUP
+        if not consumer:
+            raise ValueError("consumer is required when using a consumer group")
+
+        # Create group if needed
+        if create_group:
+            _ensure_consumer_group(client, stream, group)
+
+        # Use ">" for new entries in group, or specific ID for pending
+        read_id = start_id if start_id != "-" else ">"
+
+        result = client.xreadgroup(
+            groupname=group,
+            consumername=consumer,
+            streams={stream: read_id},
+            count=count,
+            block=block_ms,
+            noack=auto_ack,
+        )
+
+        if result:
+            for stream_name, stream_entries in result:
+                for entry_id, fields in stream_entries:
+                    entry_id_str = entry_id.decode() if isinstance(entry_id, bytes) else entry_id
+                    decoded_fields = _decode_fields(fields)
+                    entries.append((entry_id_str, decoded_fields))
+
+    elif block_ms is not None:
+        # Blocking read without group - use XREAD
+        result = client.xread(
+            streams={stream: start_id},
+            count=count,
+            block=block_ms,
+        )
+
+        if result:
+            for stream_name, stream_entries in result:
+                for entry_id, fields in stream_entries:
+                    entry_id_str = entry_id.decode() if isinstance(entry_id, bytes) else entry_id
+                    decoded_fields = _decode_fields(fields)
+                    entries.append((entry_id_str, decoded_fields))
+
+    else:
+        # Non-blocking range read - use XRANGE
+        result = client.xrange(
+            name=stream,
+            min=start_id,
+            max=end_id,
+            count=count,
+        )
+
+        for entry_id, fields in result:
+            entry_id_str = entry_id.decode() if isinstance(entry_id, bytes) else entry_id
+            decoded_fields = _decode_fields(fields)
+            entries.append((entry_id_str, decoded_fields))
+
+    return entries
+
+
+async def _read_stream_entries_async(
+    client: Any,
+    stream: str,
+    start_id: str = "$",
+    count: int | None = None,
+    block_ms: int | None = None,
+    group: str | None = None,
+    consumer: str | None = None,
+    auto_ack: bool = False,
+) -> list[tuple[str, dict[str, str]]]:
+    """Async version of _read_stream_entries."""
+    entries: list[tuple[str, dict[str, str]]] = []
+
+    if group:
+        if not consumer:
+            raise ValueError("consumer is required when using a consumer group")
+
+        read_id = start_id if start_id != ">" else ">"
+
+        result = await client.xreadgroup(
+            groupname=group,
+            consumername=consumer,
+            streams={stream: read_id},
+            count=count,
+            block=block_ms,
+            noack=auto_ack,
+        )
+
+        if result:
+            for stream_name, stream_entries in result:
+                for entry_id, fields in stream_entries:
+                    entry_id_str = entry_id.decode() if isinstance(entry_id, bytes) else entry_id
+                    decoded_fields = _decode_fields(fields)
+                    entries.append((entry_id_str, decoded_fields))
+
+    else:
+        result = await client.xread(
+            streams={stream: start_id},
+            count=count,
+            block=block_ms,
+        )
+
+        if result:
+            for stream_name, stream_entries in result:
+                for entry_id, fields in stream_entries:
+                    entry_id_str = entry_id.decode() if isinstance(entry_id, bytes) else entry_id
+                    decoded_fields = _decode_fields(fields)
+                    entries.append((entry_id_str, decoded_fields))
+
+    return entries
+
+
+def _decode_fields(fields: dict) -> dict[str, str]:
+    """Decode bytes fields to strings."""
+    decoded = {}
+    for k, v in fields.items():
+        key = k.decode() if isinstance(k, bytes) else k
+        value = v.decode() if isinstance(v, bytes) else v
+        decoded[key] = value
+    return decoded
+
+
+def _ensure_consumer_group(client: Any, stream: str, group: str) -> None:
+    """Create consumer group if it doesn't exist."""
+    try:
+        # Try to create the group, starting from ID 0 (all messages)
+        client.xgroup_create(name=stream, groupname=group, id="0", mkstream=True)
+    except Exception as e:
+        # Group already exists - that's fine
+        if "BUSYGROUP" not in str(e):
+            raise
+
+
+async def _ensure_consumer_group_async(client: Any, stream: str, group: str) -> None:
+    """Async version of _ensure_consumer_group."""
+    try:
+        await client.xgroup_create(name=stream, groupname=group, id="0", mkstream=True)
+    except Exception as e:
+        if "BUSYGROUP" not in str(e):
+            raise
+
+
+def _parse_entry_id(entry_id: str) -> tuple[int, int]:
+    """Parse entry ID into timestamp (ms) and sequence number."""
+    parts = entry_id.split("-")
+    timestamp_ms = int(parts[0])
+    sequence = int(parts[1]) if len(parts) > 1 else 0
+    return timestamp_ms, sequence
+
+
+def _entries_to_dataframe(
+    entries: list[tuple[str, dict[str, str]]],
+    schema: dict[str, pl.DataType] | None = None,
+    include_id: bool = True,
+    id_column: str = "_id",
+    include_timestamp: bool = True,
+    timestamp_column: str = "_ts",
+    include_sequence: bool = False,
+    sequence_column: str = "_seq",
+) -> pl.DataFrame:
+    """Convert stream entries to a DataFrame."""
+    if not entries:
+        # Return empty DataFrame with correct schema
+        columns: dict[str, list] = {}
+        if include_id:
+            columns[id_column] = []
+        if include_timestamp:
+            columns[timestamp_column] = []
+        if include_sequence:
+            columns[sequence_column] = []
+        if schema:
+            for name in schema:
+                columns[name] = []
+        return pl.DataFrame(columns)
+
+    # Build rows
+    rows: list[dict[str, Any]] = []
+    for entry_id, fields in entries:
+        row: dict[str, Any] = {}
+
+        if include_id:
+            row[id_column] = entry_id
+
+        if include_timestamp or include_sequence:
+            ts_ms, seq = _parse_entry_id(entry_id)
+            if include_timestamp:
+                row[timestamp_column] = ts_ms
+            if include_sequence:
+                row[sequence_column] = seq
+
+        # Add field values
+        row.update(fields)
+        rows.append(row)
+
+    df = pl.DataFrame(rows)
+
+    # Cast to schema if provided
+    if schema:
+        for name, dtype in schema.items():
+            if name in df.columns:
+                df = df.with_columns(pl.col(name).cast(dtype))
+
+    return df

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -1,0 +1,599 @@
+"""Tests for Redis Streams streaming functionality.
+
+These tests verify the streams module for single-stream consumption
+with consumer groups and continuous batch iteration.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+import uuid
+from typing import Any
+
+import polars as pl
+import pytest
+
+
+def unique_stream_name(prefix: str = "test:stream") -> str:
+    """Generate a unique stream name for testing."""
+    return f"{prefix}:{uuid.uuid4().hex[:8]}"
+
+
+def unique_group_name(prefix: str = "testgroup") -> str:
+    """Generate a unique consumer group name."""
+    return f"{prefix}:{uuid.uuid4().hex[:8]}"
+
+
+class TestReadStream:
+    """Tests for read_stream function."""
+
+    def test_read_stream_basic(self, redis_url: str, redis_available: bool) -> None:
+        """Test basic stream reading with XRANGE."""
+        if not redis_available:
+            pytest.skip("Redis not available")
+
+        import polars_redis as pr
+        import redis as redis_client
+
+        stream = unique_stream_name()
+        client = redis_client.Redis.from_url(redis_url)
+
+        try:
+            # Add entries to stream
+            for i in range(5):
+                client.xadd(
+                    stream, {"user_id": f"user_{i}", "action": "click", "value": str(i * 10)}
+                )
+
+            # Read the stream
+            df = pr.read_stream(
+                redis_url,
+                stream=stream,
+                schema={"user_id": pl.Utf8, "action": pl.Utf8, "value": pl.Int64},
+            )
+
+            assert len(df) == 5
+            assert "user_id" in df.columns
+            assert "action" in df.columns
+            assert "value" in df.columns
+            assert "_id" in df.columns
+            assert "_ts" in df.columns
+
+            # Check values
+            assert df["action"].to_list() == ["click"] * 5
+            assert df["value"].to_list() == [0, 10, 20, 30, 40]
+
+        finally:
+            client.delete(stream)
+            client.close()
+
+    def test_read_stream_with_count(self, redis_url: str, redis_available: bool) -> None:
+        """Test reading limited number of entries."""
+        if not redis_available:
+            pytest.skip("Redis not available")
+
+        import polars_redis as pr
+        import redis as redis_client
+
+        stream = unique_stream_name()
+        client = redis_client.Redis.from_url(redis_url)
+
+        try:
+            # Add 10 entries
+            for i in range(10):
+                client.xadd(stream, {"seq": str(i)})
+
+            # Read only 3
+            df = pr.read_stream(redis_url, stream=stream, count=3)
+
+            assert len(df) == 3
+
+        finally:
+            client.delete(stream)
+            client.close()
+
+    def test_read_stream_id_range(self, redis_url: str, redis_available: bool) -> None:
+        """Test reading with ID range."""
+        if not redis_available:
+            pytest.skip("Redis not available")
+
+        import polars_redis as pr
+        import redis as redis_client
+
+        stream = unique_stream_name()
+        client = redis_client.Redis.from_url(redis_url)
+
+        try:
+            # Add entries and capture IDs
+            ids = []
+            for i in range(5):
+                entry_id = client.xadd(stream, {"seq": str(i)})
+                ids.append(entry_id.decode() if isinstance(entry_id, bytes) else entry_id)
+
+            # Read only middle entries (index 1-3)
+            df = pr.read_stream(
+                redis_url,
+                stream=stream,
+                start_id=ids[1],
+                end_id=ids[3],
+            )
+
+            assert len(df) == 3
+
+        finally:
+            client.delete(stream)
+            client.close()
+
+    def test_read_stream_include_sequence(self, redis_url: str, redis_available: bool) -> None:
+        """Test including sequence number column."""
+        if not redis_available:
+            pytest.skip("Redis not available")
+
+        import polars_redis as pr
+        import redis as redis_client
+
+        stream = unique_stream_name()
+        client = redis_client.Redis.from_url(redis_url)
+
+        try:
+            client.xadd(stream, {"data": "test"})
+
+            df = pr.read_stream(
+                redis_url,
+                stream=stream,
+                include_sequence=True,
+            )
+
+            assert "_seq" in df.columns
+            assert df["_seq"][0] == 0  # First entry in ms has sequence 0
+
+        finally:
+            client.delete(stream)
+            client.close()
+
+    def test_read_stream_custom_columns(self, redis_url: str, redis_available: bool) -> None:
+        """Test custom column names."""
+        if not redis_available:
+            pytest.skip("Redis not available")
+
+        import polars_redis as pr
+        import redis as redis_client
+
+        stream = unique_stream_name()
+        client = redis_client.Redis.from_url(redis_url)
+
+        try:
+            client.xadd(stream, {"data": "test"})
+
+            df = pr.read_stream(
+                redis_url,
+                stream=stream,
+                id_column="entry_id",
+                timestamp_column="entry_ts",
+                include_sequence=True,
+                sequence_column="entry_seq",
+            )
+
+            assert "entry_id" in df.columns
+            assert "entry_ts" in df.columns
+            assert "entry_seq" in df.columns
+            assert "_id" not in df.columns
+            assert "_ts" not in df.columns
+
+        finally:
+            client.delete(stream)
+            client.close()
+
+    def test_read_stream_empty(self, redis_url: str, redis_available: bool) -> None:
+        """Test reading from empty/non-existent stream."""
+        if not redis_available:
+            pytest.skip("Redis not available")
+
+        import polars_redis as pr
+
+        stream = unique_stream_name()
+
+        df = pr.read_stream(
+            redis_url,
+            stream=stream,
+            schema={"field": pl.Utf8},
+        )
+
+        assert len(df) == 0
+        assert "_id" in df.columns
+        assert "field" in df.columns
+
+
+class TestReadStreamConsumerGroup:
+    """Tests for consumer group functionality."""
+
+    def test_consumer_group_basic(self, redis_url: str, redis_available: bool) -> None:
+        """Test basic consumer group reading."""
+        if not redis_available:
+            pytest.skip("Redis not available")
+
+        import polars_redis as pr
+        import redis as redis_client
+
+        stream = unique_stream_name()
+        group = unique_group_name()
+        client = redis_client.Redis.from_url(redis_url)
+
+        try:
+            # Add entries
+            for i in range(5):
+                client.xadd(stream, {"seq": str(i)})
+
+            # Read with consumer group
+            df = pr.read_stream(
+                redis_url,
+                stream=stream,
+                group=group,
+                consumer="worker-1",
+                auto_ack=True,
+            )
+
+            assert len(df) == 5
+
+            # Reading again should return nothing (all consumed)
+            df2 = pr.read_stream(
+                redis_url,
+                stream=stream,
+                group=group,
+                consumer="worker-1",
+                block_ms=100,  # Short block
+            )
+
+            assert len(df2) == 0
+
+        finally:
+            client.delete(stream)
+            client.close()
+
+    def test_consumer_group_manual_ack(self, redis_url: str, redis_available: bool) -> None:
+        """Test manual acknowledgment of entries."""
+        if not redis_available:
+            pytest.skip("Redis not available")
+
+        import polars_redis as pr
+        import redis as redis_client
+
+        stream = unique_stream_name()
+        group = unique_group_name()
+        client = redis_client.Redis.from_url(redis_url)
+
+        try:
+            # Add entries
+            for i in range(3):
+                client.xadd(stream, {"seq": str(i)})
+
+            # Read without auto-ack
+            df = pr.read_stream(
+                redis_url,
+                stream=stream,
+                group=group,
+                consumer="worker-1",
+                auto_ack=False,
+            )
+
+            assert len(df) == 3
+
+            # Acknowledge entries
+            entry_ids = df["_id"].to_list()
+            acked = pr.ack_entries(redis_url, stream, group, entry_ids)
+
+            assert acked == 3
+
+        finally:
+            client.delete(stream)
+            client.close()
+
+    def test_multiple_consumers(self, redis_url: str, redis_available: bool) -> None:
+        """Test multiple consumers in same group."""
+        if not redis_available:
+            pytest.skip("Redis not available")
+
+        import polars_redis as pr
+        import redis as redis_client
+
+        stream = unique_stream_name()
+        group = unique_group_name()
+        client = redis_client.Redis.from_url(redis_url)
+
+        try:
+            # Add entries
+            for i in range(6):
+                client.xadd(stream, {"seq": str(i)})
+
+            # Consumer 1 reads 3
+            df1 = pr.read_stream(
+                redis_url,
+                stream=stream,
+                group=group,
+                consumer="worker-1",
+                count=3,
+                auto_ack=True,
+            )
+
+            # Consumer 2 reads remaining
+            df2 = pr.read_stream(
+                redis_url,
+                stream=stream,
+                group=group,
+                consumer="worker-2",
+                auto_ack=True,
+            )
+
+            assert len(df1) == 3
+            assert len(df2) == 3
+
+            # No overlap in entries
+            ids1 = set(df1["_id"].to_list())
+            ids2 = set(df2["_id"].to_list())
+            assert len(ids1 & ids2) == 0
+
+        finally:
+            client.delete(stream)
+            client.close()
+
+
+class TestScanStream:
+    """Tests for scan_stream (lazy) function."""
+
+    def test_scan_stream_lazy(self, redis_url: str, redis_available: bool) -> None:
+        """Test lazy stream scanning."""
+        if not redis_available:
+            pytest.skip("Redis not available")
+
+        import polars_redis as pr
+        import redis as redis_client
+
+        stream = unique_stream_name()
+        client = redis_client.Redis.from_url(redis_url)
+
+        try:
+            for i in range(5):
+                client.xadd(stream, {"value": str(i * 10)})
+
+            lf = pr.scan_stream(
+                redis_url,
+                stream=stream,
+                schema={"value": pl.Int64},
+            )
+
+            # Should be a LazyFrame
+            assert isinstance(lf, pl.LazyFrame)
+
+            # Apply lazy operations
+            result = lf.filter(pl.col("value") > 10).collect()
+
+            assert len(result) == 3  # 20, 30, 40
+
+        finally:
+            client.delete(stream)
+            client.close()
+
+
+class TestIterStream:
+    """Tests for iter_stream batch iterator."""
+
+    def test_iter_stream_basic(self, redis_url: str, redis_available: bool) -> None:
+        """Test basic batch iteration."""
+        if not redis_available:
+            pytest.skip("Redis not available")
+
+        import threading
+
+        import polars_redis as pr
+        import redis as redis_client
+
+        stream = unique_stream_name()
+        client = redis_client.Redis.from_url(redis_url)
+        stop_flag = threading.Event()
+
+        def add_entries() -> None:
+            time.sleep(0.1)
+            for i in range(15):
+                if stop_flag.is_set():
+                    break
+                client.xadd(stream, {"seq": str(i)})
+                time.sleep(0.05)
+
+        thread = threading.Thread(target=add_entries)
+        thread.start()
+
+        try:
+            batches = []
+            for batch in pr.iter_stream(
+                redis_url,
+                stream=stream,
+                batch_size=5,
+                block_ms=2000,
+            ):
+                batches.append(batch)
+                if len(batches) >= 2:
+                    stop_flag.set()
+                    break
+
+            thread.join()
+
+            assert len(batches) >= 1
+
+        finally:
+            stop_flag.set()
+            thread.join()
+            client.delete(stream)
+            client.close()
+
+    def test_iter_stream_consumer_group(self, redis_url: str, redis_available: bool) -> None:
+        """Test batch iteration with consumer group."""
+        if not redis_available:
+            pytest.skip("Redis not available")
+
+        import threading
+
+        import polars_redis as pr
+        import redis as redis_client
+
+        stream = unique_stream_name()
+        group = unique_group_name()
+        client = redis_client.Redis.from_url(redis_url)
+        stop_flag = threading.Event()
+
+        def add_entries() -> None:
+            time.sleep(0.1)
+            for i in range(10):
+                if stop_flag.is_set():
+                    break
+                client.xadd(stream, {"seq": str(i)})
+                time.sleep(0.05)
+
+        thread = threading.Thread(target=add_entries)
+        thread.start()
+
+        try:
+            batches = []
+            for batch in pr.iter_stream(
+                redis_url,
+                stream=stream,
+                group=group,
+                consumer="worker-1",
+                batch_size=5,
+                block_ms=2000,
+                auto_ack=True,
+            ):
+                batches.append(batch)
+                if len(batches) >= 2:
+                    stop_flag.set()
+                    break
+
+            thread.join()
+
+            assert len(batches) >= 1
+
+        finally:
+            stop_flag.set()
+            thread.join()
+            client.delete(stream)
+            client.close()
+
+
+class TestStreamBatches:
+    """Tests for stream_batches async iterator."""
+
+    @pytest.mark.asyncio
+    async def test_stream_batches_basic(self, redis_url: str, redis_available: bool) -> None:
+        """Test basic async batch iteration."""
+        if not redis_available:
+            pytest.skip("Redis not available")
+
+        import polars_redis as pr
+        import redis as redis_client
+
+        stream = unique_stream_name()
+        client = redis_client.Redis.from_url(redis_url)
+
+        async def add_entries() -> None:
+            await asyncio.sleep(0.1)
+            for i in range(10):
+                client.xadd(stream, {"seq": str(i)})
+                await asyncio.sleep(0.05)
+
+        add_task = asyncio.create_task(add_entries())
+
+        try:
+            batches = []
+            async for batch in pr.stream_batches(
+                redis_url,
+                stream=stream,
+                batch_size=5,
+                batch_timeout_ms=2000,
+            ):
+                batches.append(batch)
+                if len(batches) >= 2:
+                    break
+
+            await add_task
+
+            assert len(batches) >= 1
+
+        finally:
+            client.delete(stream)
+            client.close()
+
+
+class TestStreamsUnit:
+    """Unit tests that don't require extensive Redis setup."""
+
+    def test_imports(self) -> None:
+        """Test that stream functions are importable."""
+        from polars_redis import (
+            ack_entries,
+            iter_stream,
+            read_stream,
+            scan_stream,
+            stream_batches,
+        )
+
+        assert callable(read_stream)
+        assert callable(scan_stream)
+        assert callable(iter_stream)
+        assert callable(stream_batches)
+        assert callable(ack_entries)
+
+    def test_read_stream_signature(self) -> None:
+        """Test function signature includes expected parameters."""
+        import inspect
+
+        from polars_redis import read_stream
+
+        sig = inspect.signature(read_stream)
+        params = set(sig.parameters.keys())
+
+        expected = {
+            "url",
+            "stream",
+            "schema",
+            "start_id",
+            "end_id",
+            "count",
+            "block_ms",
+            "group",
+            "consumer",
+            "auto_ack",
+            "create_group",
+            "include_id",
+            "id_column",
+            "include_timestamp",
+            "timestamp_column",
+            "include_sequence",
+            "sequence_column",
+        }
+
+        assert expected.issubset(params)
+
+    def test_empty_stream_with_schema(self, redis_url: str, redis_available: bool) -> None:
+        """Test empty stream returns DataFrame with correct schema."""
+        if not redis_available:
+            pytest.skip("Redis not available")
+
+        import polars_redis as pr
+
+        stream = unique_stream_name()
+
+        df = pr.read_stream(
+            redis_url,
+            stream=stream,
+            schema={"field1": pl.Int64, "field2": pl.Utf8},
+            include_id=True,
+            include_timestamp=True,
+            include_sequence=True,
+        )
+
+        assert len(df) == 0
+        assert "_id" in df.columns
+        assert "_ts" in df.columns
+        assert "_seq" in df.columns
+        assert "field1" in df.columns
+        assert "field2" in df.columns


### PR DESCRIPTION
## Summary

Implements Redis Streams as a streaming DataFrame source as described in issue #120.

## Changes

### New Functions

- **`read_stream()`** - Read entries from a single stream into DataFrame
  - Uses XRANGE for non-blocking reads
  - Uses XREAD for blocking reads
  - Uses XREADGROUP for consumer group reads

- **`scan_stream()`** - Lazy version returning LazyFrame

- **`iter_stream()`** - Sync iterator yielding DataFrame batches

- **`stream_batches()`** - Async iterator yielding DataFrame batches

- **`ack_entries()`** - Manually acknowledge messages in consumer groups

### Features

- Consumer group support with automatic group creation
- Blocking reads for real-time tailing (`block_ms` parameter)
- Manual or automatic message acknowledgment (`auto_ack`)
- Entry ID parsing into timestamp and sequence columns
- Schema casting for typed columns
- Custom column naming

### Tests

- 16 comprehensive tests in `tests/test_streams.py`
- Tests for basic reads, count limits, ID ranges
- Tests for consumer groups, manual ack, multiple consumers
- Tests for batch iteration (sync and async)

### Documentation

- Full guide at `docs/guide/streams.md`
- API reference with examples
- Added to mkdocs navigation

## Example Usage

```python
import polars_redis as redis

# Basic read
df = redis.read_stream(
    "redis://localhost",
    stream="events",
    schema={"user_id": pl.Utf8, "action": pl.Utf8},
)

# Consumer group with auto-ack
df = redis.read_stream(
    "redis://localhost",
    stream="events",
    group="analytics",
    consumer="worker-1",
    auto_ack=True,
)

# Continuous batch iteration
for batch_df in redis.iter_stream(
    "redis://localhost",
    stream="events",
    batch_size=100,
    block_ms=1000,
):
    process(batch_df)
```

## Differences from Existing `scan_streams`/`read_streams`

The existing functions scan **multiple streams** by key pattern. This PR adds functions for:

1. **Single stream consumption** with consumer groups
2. **Blocking reads** for real-time tailing
3. **Continuous streaming** with batch iterators

Closes #120