### PR TITLE
chore: update branch references from master to main

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -2,14 +2,14 @@ name: Benchmarks
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths:
       - "src/**"
       - "benches/**"
       - "Cargo.toml"
       - "Cargo.lock"
   pull_request:
-    branches: [master]
+    branches: [main]
     paths:
       - "src/**"
       - "benches/**"
@@ -58,8 +58,8 @@ jobs:
           tool: cargo
           output-file-path: output.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          # Only push to gh-pages on master
-          auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+          # Only push to gh-pages on main
+          auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           # Alert if performance regresses by more than 15%
           alert-threshold: "115%"
           # Comment on commit/PR when alert threshold exceeded

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master, main]
+    branches: [main]
     paths-ignore:
       - "**.md"
       - "docs/**"
@@ -10,7 +10,7 @@ on:
       - ".github/workflows/docs.yml"
       - ".github/workflows/benchmarks.yml"
   pull_request:
-    branches: [master, main]
+    branches: [main]
     paths-ignore:
       - "**.md"
       - "docs/**"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Docs
 
 on:
   push:
-    branches: [master, main]
+    branches: [main]
     paths:
       - "docs/**"
       - "mkdocs.yml"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,7 +3,7 @@ name: Release Please
 on:
   push:
     branches:
-      - master
+      - main
 
 permissions:
   contents: write

--- a/docs/examples/python.md
+++ b/docs/examples/python.md
@@ -1,6 +1,6 @@
 # Python Examples
 
-Example scripts are in [`examples/python/`](https://github.com/joshrotenberg/polars-redis/tree/master/examples/python).
+Example scripts are in [`examples/python/`](https://github.com/joshrotenberg/polars-redis/tree/main/examples/python).
 
 ## Basic Hashes
 

--- a/docs/examples/rust.md
+++ b/docs/examples/rust.md
@@ -1,6 +1,6 @@
 # Rust Examples
 
-Example code is in [`examples/rust/`](https://github.com/joshrotenberg/polars-redis/tree/master/examples/rust).
+Example code is in [`examples/rust/`](https://github.com/joshrotenberg/polars-redis/tree/main/examples/rust).
 
 Run examples with:
 


### PR DESCRIPTION
## Summary

Updates all references from `master` to `main` after the branch rename.

## Changes

### CI Workflows
- `.github/workflows/benchmarks.yml` - Updated triggers and gh-pages push condition
- `.github/workflows/ci.yml` - Updated triggers
- `.github/workflows/docs.yml` - Updated triggers  
- `.github/workflows/release-please.yml` - Updated triggers

### Documentation
- `docs/examples/python.md` - Updated GitHub link
- `docs/examples/rust.md` - Updated GitHub link

Note: References to Redis cluster "master" nodes in Rust code are intentional and unchanged.