### PR TITLE
docs: reorganize navigation structure

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,27 +63,31 @@ nav:
   - Getting Started:
       - Installation: getting-started/installation.md
       - Quick Start: getting-started/quickstart.md
-  - User Guide:
+  - Scanning & Writing:
       - Scanning Data: guide/scanning.md
-      - RediSearch: guide/redisearch.md
       - Writing Data: guide/writing.md
-      - DataFrame Caching: guide/caching.md
-      - Pub/Sub Streaming: guide/pubsub.md
-      - Streams Consumption: guide/streams.md
       - Schema Inference: guide/schema-inference.md
+  - Caching & Streaming:
+      - DataFrame Caching: guide/caching.md
+      - Pub/Sub: guide/pubsub.md
+      - Redis Streams: guide/streams.md
+  - RediSearch:
+      - Queries & Aggregation: guide/redisearch.md
+      - Advanced Queries: examples/advanced-queries.md
+  - Operations:
       - Configuration: guide/configuration.md
       - Performance: guide/performance.md
       - Cluster Support: guide/cluster.md
+      - Migration Guide: guide/migration.md
+  - Patterns:
       - Use Cases: guide/use-cases.md
       - Ephemeral Workbench: guide/ephemeral-workbench.md
-      - Migration Guide: guide/migration.md
   - API Reference:
       - Python API: api/python.md
       - Rust API: api/rust.md
   - Examples:
       - Python Examples: examples/python.md
       - Rust Examples: examples/rust.md
-      - Advanced Queries: examples/advanced-queries.md
   - Presentation: slides.md
 
 extra:


### PR DESCRIPTION
## Summary

Reorganizes the flat "User Guide" navigation into logical sections for better discoverability.

## New Structure

| Section | Contents |
|---------|----------|
| **Scanning & Writing** | Core data operations - scanning, writing, schema inference |
| **Caching & Streaming** | DataFrame caching, Pub/Sub, Redis Streams |
| **RediSearch** | Queries & aggregation, advanced query examples |
| **Operations** | Configuration, performance, cluster support, migration |
| **Patterns** | Use cases, ephemeral workbench |

## Changes

- Broke apart the 12-item flat "User Guide" into 5 focused sections
- Moved "Advanced Queries" under RediSearch where it fits better
- Renamed sections for clarity (e.g., "Pub/Sub Streaming" -> "Pub/Sub")

## Before/After

**Before:**
```
User Guide (12 items)
  - Scanning Data
  - RediSearch
  - Writing Data
  - DataFrame Caching
  - Pub/Sub Streaming
  - Streams Consumption
  - Schema Inference
  - Configuration
  - Performance
  - Cluster Support
  - Use Cases
  - Ephemeral Workbench
  - Migration Guide
```

**After:**
```
Scanning & Writing
  - Scanning Data
  - Writing Data
  - Schema Inference
Caching & Streaming
  - DataFrame Caching
  - Pub/Sub
  - Redis Streams
RediSearch
  - Queries & Aggregation
  - Advanced Queries
Operations
  - Configuration
  - Performance
  - Cluster Support
  - Migration Guide
Patterns
  - Use Cases
  - Ephemeral Workbench
```