### PR TITLE
chore: align with Polars conventions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,3 +73,7 @@ path = "examples/rust/scan_hashes.rs"
 [[example]]
 name = "scan_json"
 path = "examples/rust/scan_json.rs"
+
+# Clippy lints aligned with Polars conventions
+[lints.clippy]
+collapsible_if = "allow"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,14 @@
+# Formatting configuration aligned with Polars conventions
+# See: https://docs.pola.rs/development/contributing/
+#
+# Note: group_imports and imports_granularity require nightly rustfmt.
+# Polars uses nightly for these features. We keep them commented for
+# documentation but use stable-compatible settings.
+
+# Stable rustfmt settings
+match_block_trailing_comma = true
+use_field_init_shorthand = true
+
+# Nightly-only settings (uncomment if using nightly rustfmt)
+# group_imports = "StdExternalCrate"
+# imports_granularity = "Module"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -572,7 +572,7 @@ async fn cache_info_async(url: &str, key: &str) -> Result<Option<CacheInfo>> {
                 chunk_size: d.len(),
                 ttl: if ttl < 0 { None } else { Some(ttl) },
             }))
-        }
+        },
         None => Ok(None),
     }
 }
@@ -611,7 +611,7 @@ fn serialize_batch(batch: &RecordBatch, config: &CacheConfig) -> Result<Vec<u8>>
         CacheFormat::Ipc => serialize_ipc(batch, config.ipc_compression),
         CacheFormat::Parquet => {
             serialize_parquet(batch, config.parquet_compression, config.compression_level)
-        }
+        },
     }
 }
 
@@ -667,7 +667,7 @@ fn serialize_parquet(
                 .map(|l| parquet::basic::ZstdLevel::try_new(l).unwrap_or_default())
                 .unwrap_or_default();
             ParquetCompression::ZSTD(zstd_level)
-        }
+        },
     };
 
     let props = WriterProperties::builder()

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -161,7 +161,7 @@ fn parse_cluster_slots_for_masters(value: &Value) -> Result<Vec<String>> {
             return Err(Error::Runtime(
                 "Unexpected CLUSTER SLOTS response format".to_string(),
             ));
-        }
+        },
     };
 
     for slot_range in slots {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -217,7 +217,7 @@ impl RedisConnection {
                     #[cfg(feature = "cluster")]
                     cluster_client: None,
                 })
-            }
+            },
             #[cfg(feature = "cluster")]
             ConnectionConfig::Cluster { nodes } => {
                 let cluster_client = ClusterClient::new(nodes.clone())
@@ -227,7 +227,7 @@ impl RedisConnection {
                     client: None,
                     cluster_client: Some(cluster_client),
                 })
-            }
+            },
         }
     }
 
@@ -263,12 +263,12 @@ impl RedisConnection {
             ConnectionConfig::Single { .. } => {
                 let manager = self.get_connection_manager().await?;
                 Ok(RedisConn::Single(manager))
-            }
+            },
             #[cfg(feature = "cluster")]
             ConnectionConfig::Cluster { .. } => {
                 let cluster = self.get_cluster_connection().await?;
                 Ok(RedisConn::Cluster(cluster))
-            }
+            },
         }
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -59,16 +59,16 @@ impl From<Error> for pyo3::PyErr {
         match err {
             Error::Connection(_) | Error::InvalidUrl(_) => {
                 pyo3::exceptions::PyConnectionError::new_err(err.to_string())
-            }
+            },
             Error::SchemaMismatch(_) | Error::TypeConversion(_) => {
                 pyo3::exceptions::PyValueError::new_err(err.to_string())
-            }
+            },
             Error::Io(_) => pyo3::exceptions::PyIOError::new_err(err.to_string()),
             Error::Runtime(_) => pyo3::exceptions::PyRuntimeError::new_err(err.to_string()),
             Error::KeyNotFound(_) => pyo3::exceptions::PyKeyError::new_err(err.to_string()),
             Error::JsonModuleNotAvailable => {
                 pyo3::exceptions::PyRuntimeError::new_err(err.to_string())
-            }
+            },
             Error::InvalidInput(_) => pyo3::exceptions::PyValueError::new_err(err.to_string()),
             Error::KeyExists(_) => pyo3::exceptions::PyValueError::new_err(err.to_string()),
             Error::Channel(_) => pyo3::exceptions::PyRuntimeError::new_err(err.to_string()),

--- a/src/index.rs
+++ b/src/index.rs
@@ -954,7 +954,7 @@ impl Index {
                         field = field.sortable();
                     }
                     index = index.with_field(field);
-                }
+                },
                 RedisType::Utf8 => {
                     if text_set.contains(field_name.as_str()) {
                         let mut field = TextField::new(field_name);
@@ -969,14 +969,14 @@ impl Index {
                         }
                         index = index.with_field(field);
                     }
-                }
+                },
                 RedisType::Boolean => {
                     let mut field = TagField::new(field_name);
                     if is_sortable {
                         field = field.sortable();
                     }
                     index = index.with_field(field);
-                }
+                },
                 RedisType::Date | RedisType::Datetime => {
                     // Date/Datetime are stored as strings, treat as TAG for exact match
                     // or use NUMERIC if stored as timestamps
@@ -985,7 +985,7 @@ impl Index {
                         field = field.sortable();
                     }
                     index = index.with_field(field);
-                }
+                },
             }
         }
 

--- a/src/infer.rs
+++ b/src/infer.rs
@@ -691,7 +691,7 @@ fn json_value_type(value: &serde_json::Value) -> &'static str {
             } else {
                 "number"
             }
-        }
+        },
         serde_json::Value::String(_) => "string",
         serde_json::Value::Array(_) => "array",
         serde_json::Value::Object(_) => "object",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -465,7 +465,7 @@ impl PyHashBatchIterator {
                 }
 
                 Ok(Some(pyo3::types::PyBytes::new(py, &buf).into()))
-            }
+            },
             None => Ok(None),
         }
     }
@@ -821,7 +821,7 @@ impl PyClusterHashBatchIterator {
                 }
 
                 Ok(Some(pyo3::types::PyBytes::new(py, &buf).into()))
-            }
+            },
             None => Ok(None),
         }
     }
@@ -965,7 +965,7 @@ impl PyClusterJsonBatchIterator {
                 }
 
                 Ok(Some(pyo3::types::PyBytes::new(py, &buf).into()))
-            }
+            },
             None => Ok(None),
         }
     }
@@ -1037,7 +1037,7 @@ impl PyClusterStringBatchIterator {
                     "Unknown value type '{}'. Supported: utf8, int64, float64, bool, date, datetime",
                     value_type
                 )));
-            }
+            },
         };
 
         let string_schema = StringSchema::new(dtype)
@@ -1102,7 +1102,7 @@ impl PyClusterStringBatchIterator {
                 }
 
                 Ok(Some(pyo3::types::PyBytes::new(py, &buf).into()))
-            }
+            },
             None => Ok(None),
         }
     }
@@ -1273,7 +1273,7 @@ impl PyHashSearchIterator {
                 }
 
                 Ok(Some(pyo3::types::PyBytes::new(py, &buf).into()))
-            }
+            },
             None => Ok(None),
         }
     }
@@ -1575,7 +1575,7 @@ impl PyTimeSeriesBatchIterator {
                 }
 
                 Ok(Some(pyo3::types::PyBytes::new(py, &buf).into()))
-            }
+            },
             None => Ok(None),
         }
     }
@@ -1743,7 +1743,7 @@ impl PyJsonBatchIterator {
                 }
 
                 Ok(Some(pyo3::types::PyBytes::new(py, &buf).into()))
-            }
+            },
             None => Ok(None),
         }
     }
@@ -1832,7 +1832,7 @@ impl PyStringBatchIterator {
                     "Unknown value type '{}'. Supported: utf8, int64, float64, bool, date, datetime",
                     value_type
                 )));
-            }
+            },
         };
 
         let string_schema = StringSchema::new(dtype)
@@ -1902,7 +1902,7 @@ impl PyStringBatchIterator {
                 }
 
                 Ok(Some(pyo3::types::PyBytes::new(py, &buf).into()))
-            }
+            },
             None => Ok(None),
         }
     }
@@ -2492,7 +2492,7 @@ impl PyListBatchIterator {
                 }
 
                 Ok(Some(pyo3::types::PyBytes::new(py, &buf).into()))
-            }
+            },
             None => Ok(None),
         }
     }
@@ -2714,7 +2714,7 @@ impl PySetBatchIterator {
                 }
 
                 Ok(Some(pyo3::types::PyBytes::new(py, &buf).into()))
-            }
+            },
             None => Ok(None),
         }
     }
@@ -2886,7 +2886,7 @@ impl PyZSetBatchIterator {
                 }
 
                 Ok(Some(pyo3::types::PyBytes::new(py, &buf).into()))
-            }
+            },
             None => Ok(None),
         }
     }
@@ -3085,7 +3085,7 @@ impl PyStreamBatchIterator {
                 }
 
                 Ok(Some(pyo3::types::PyBytes::new(py, &buf).into()))
-            }
+            },
             None => Ok(None),
         }
     }

--- a/src/parallel.rs
+++ b/src/parallel.rs
@@ -177,13 +177,13 @@ impl<F: ParallelFetch> ParallelFetcher<F> {
                             match fetcher.fetch(conn.clone(), keys).await {
                                 Ok(data) => {
                                     let _ = result_tx.send(FetchResult { data, sequence }).await;
-                                }
+                                },
                                 Err(_e) => {
                                     // Error in fetch, continue processing
                                     // TODO: Consider adding error channel for reporting
-                                }
+                                },
                             }
-                        }
+                        },
                         None => break, // Channel closed, exit worker
                     }
                 }

--- a/src/pubsub.rs
+++ b/src/pubsub.rs
@@ -244,17 +244,17 @@ async fn collect_pubsub_async(url: &str, config: &PubSubConfig) -> Result<Record
                     payload,
                     received_at,
                 });
-            }
+            },
             Ok(None) => {
                 // Stream ended
                 break;
-            }
+            },
             Err(_) => {
                 // Timeout - check if we should continue
                 if deadline.is_some() {
                     break;
                 }
-            }
+            },
         }
     }
 

--- a/src/query_builder.rs
+++ b/src/query_builder.rs
@@ -461,7 +461,7 @@ impl Predicate {
             Predicate::And(mut preds) => {
                 preds.push(other);
                 Predicate::And(preds)
-            }
+            },
             _ => Predicate::And(vec![self, other]),
         }
     }
@@ -472,7 +472,7 @@ impl Predicate {
             Predicate::Or(mut preds) => {
                 preds.push(other);
                 Predicate::Or(preds)
-            }
+            },
             _ => Predicate::Or(vec![self, other]),
         }
     }
@@ -509,7 +509,7 @@ impl Predicate {
                     .collect();
                 let wkt = format!("POLYGON(({}))", coords.join(", "));
                 params.push(("poly".to_string(), wkt));
-            }
+            },
             Predicate::VectorKnn {
                 vector_param,
                 pre_filter,
@@ -521,19 +521,19 @@ impl Predicate {
                 if let Some(filter) = pre_filter {
                     filter.collect_params(params);
                 }
-            }
+            },
             Predicate::VectorRange { vector_param, .. } => {
                 params.push((vector_param.clone(), String::new()));
-            }
+            },
             Predicate::And(preds) | Predicate::Or(preds) => {
                 for p in preds {
                     p.collect_params(params);
                 }
-            }
+            },
             Predicate::Not(inner) | Predicate::Optional(inner) | Predicate::Boost(inner, _) => {
                 inner.collect_params(params);
-            }
-            _ => {}
+            },
+            _ => {},
         }
     }
 
@@ -547,29 +547,29 @@ impl Predicate {
                 } else {
                     format!("@{}:{{{}}}", field, escape_tag_value(&value.to_string()))
                 }
-            }
+            },
             Predicate::Ne(field, value) => {
                 if value.is_numeric() {
                     format!("-@{}:[{} {}]", field, value, value)
                 } else {
                     format!("-@{}:{{{}}}", field, escape_tag_value(&value.to_string()))
                 }
-            }
+            },
             Predicate::Gt(field, value) => {
                 format!("@{}:[({} +inf]", field, value)
-            }
+            },
             Predicate::Gte(field, value) => {
                 format!("@{}:[{} +inf]", field, value)
-            }
+            },
             Predicate::Lt(field, value) => {
                 format!("@{}:[-inf ({}]", field, value)
-            }
+            },
             Predicate::Lte(field, value) => {
                 format!("@{}:[-inf {}]", field, value)
-            }
+            },
             Predicate::Between(field, min, max) => {
                 format!("@{}:[{} {}]", field, min, max)
-            }
+            },
 
             // Logical
             Predicate::And(preds) => {
@@ -589,7 +589,7 @@ impl Predicate {
                         .collect::<Vec<_>>()
                         .join(" ")
                 }
-            }
+            },
             Predicate::Or(preds) => {
                 if preds.is_empty() {
                     "*".to_string()
@@ -607,37 +607,37 @@ impl Predicate {
                         .collect::<Vec<_>>()
                         .join(" | ")
                 }
-            }
+            },
             Predicate::Not(inner) => {
                 format!("-({})", inner.to_query())
-            }
+            },
 
             // Text search
             Predicate::TextSearch(field, term) => {
                 format!("@{}:{}", field, escape_text_value(term))
-            }
+            },
             Predicate::Prefix(field, prefix) => {
                 format!("@{}:{}*", field, escape_text_value(prefix))
-            }
+            },
             Predicate::Suffix(field, suffix) => {
                 format!("@{}:*{}", field, escape_text_value(suffix))
-            }
+            },
             Predicate::Infix(field, substring) => {
                 format!("@{}:*{}*", field, escape_text_value(substring))
-            }
+            },
             Predicate::Wildcard(field, pattern) => {
                 format!("@{}:{}", field, pattern)
-            }
+            },
             Predicate::WildcardExact(field, pattern) => {
                 format!("@{}:\"w'{}\"", field, pattern)
-            }
+            },
             Predicate::Fuzzy(field, term, distance) => {
                 let pct = "%".repeat(*distance as usize);
                 format!("@{}:{}{}{}", field, pct, escape_text_value(term), pct)
-            }
+            },
             Predicate::Phrase(field, words) => {
                 format!("@{}:({})", field, words.join(" "))
-            }
+            },
             Predicate::PhraseWithOptions {
                 field,
                 words,
@@ -657,29 +657,29 @@ impl Predicate {
                 } else {
                     format!("@{}:({}) => {{ {}; }}", field, phrase, attrs.join("; "))
                 }
-            }
+            },
             Predicate::Optional(inner) => {
                 format!("~{}", inner.to_query())
-            }
+            },
 
             // Tags
             Predicate::Tag(field, tag) => {
                 format!("@{}:{{{}}}", field, escape_tag_value(tag))
-            }
+            },
             Predicate::TagOr(field, tags) => {
                 let escaped: Vec<String> = tags.iter().map(|t| escape_tag_value(t)).collect();
                 format!("@{}:{{{}}}", field, escaped.join("|"))
-            }
+            },
 
             // Multi-field search
             Predicate::MultiFieldSearch(fields, term) => {
                 format!("@{}:{}", fields.join("|"), escape_text_value(term))
-            }
+            },
 
             // Geo
             Predicate::GeoRadius(field, lon, lat, radius, unit) => {
                 format!("@{}:[{} {} {} {}]", field, lon, lat, radius, unit)
-            }
+            },
             Predicate::GeoPolygon { field, points } => {
                 // Format: @field:[WITHIN $poly] with PARAMS containing WKT polygon
                 // For query string, we output the WITHIN syntax
@@ -691,20 +691,20 @@ impl Predicate {
                     .collect();
                 // Note: The actual WKT polygon is passed via PARAMS 2 poly "POLYGON((...))""
                 format!("@{}:[WITHIN $poly]", field)
-            }
+            },
 
             // Null checks
             Predicate::IsMissing(field) => {
                 format!("ismissing(@{})", field)
-            }
+            },
             Predicate::IsNotMissing(field) => {
                 format!("-ismissing(@{})", field)
-            }
+            },
 
             // Boost
             Predicate::Boost(inner, weight) => {
                 format!("({}) => {{ $weight: {}; }}", inner.to_query(), weight)
-            }
+            },
 
             // Vector search
             Predicate::VectorKnn {
@@ -718,14 +718,14 @@ impl Predicate {
                     .map(|p| p.to_query())
                     .unwrap_or_else(|| "*".to_string());
                 format!("{}=>[KNN {} @{} ${}]", filter, k, field, vector_param)
-            }
+            },
             Predicate::VectorRange {
                 field,
                 radius,
                 vector_param,
             } => {
                 format!("@{}:[VECTOR_RANGE {} ${}]", field, radius, vector_param)
-            }
+            },
 
             // Raw
             Predicate::Raw(query) => query.clone(),
@@ -742,7 +742,7 @@ fn escape_tag_value(s: &str) -> String {
             | '#' | '$' | '%' | '^' | '&' | '*' | '(' | ')' | '-' | '+' | '=' | '~' | ' ' => {
                 result.push('\\');
                 result.push(c);
-            }
+            },
             _ => result.push(c),
         }
     }
@@ -757,7 +757,7 @@ fn escape_text_value(s: &str) -> String {
             '@' | '{' | '}' | '[' | ']' | '(' | ')' | '|' | '-' | '~' => {
                 result.push('\\');
                 result.push(c);
-            }
+            },
             _ => result.push(c),
         }
     }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -63,7 +63,7 @@ impl RedisType {
                     .ok_or_else(|| {
                         Error::TypeConversion(format!("Failed to parse '{}' as datetime", value))
                     })
-            }
+            },
         }
     }
 }

--- a/src/search.rs
+++ b/src/search.rs
@@ -405,7 +405,7 @@ fn parse_search_response(value: redis::Value) -> Result<SearchResult> {
                     _ => {
                         i += 1;
                         continue;
-                    }
+                    },
                 };
                 i += 1;
 
@@ -426,7 +426,7 @@ fn parse_search_response(value: redis::Value) -> Result<SearchResult> {
             }
 
             Ok(SearchResult { total, documents })
-        }
+        },
         _ => Ok(SearchResult {
             total: 0,
             documents: Vec::new(),
@@ -446,7 +446,7 @@ fn parse_field_array(arr: &[redis::Value]) -> HashMap<String, Option<String>> {
             _ => {
                 i += 2;
                 continue;
-            }
+            },
         };
 
         let field_value = match &arr[i + 1] {
@@ -847,7 +847,7 @@ fn parse_aggregate_response(value: redis::Value) -> Result<AggregateResult> {
             }
 
             Ok(AggregateResult { rows })
-        }
+        },
         _ => Ok(AggregateResult { rows: Vec::new() }),
     }
 }
@@ -864,7 +864,7 @@ fn parse_aggregate_row(arr: &[redis::Value]) -> HashMap<String, String> {
             _ => {
                 i += 2;
                 continue;
-            }
+            },
         };
 
         let field_value = match &arr[i + 1] {

--- a/src/smart.rs
+++ b/src/smart.rs
@@ -181,7 +181,7 @@ async fn get_index_info(
             _ => {
                 i += 2;
                 continue;
-            }
+            },
         };
         info_map.insert(key, info[i + 1].clone());
         i += 2;
@@ -199,13 +199,13 @@ async fn get_index_info(
                     _ => {
                         j += 2;
                         continue;
-                    }
+                    },
                 };
                 def_map.insert(k, arr[j + 1].clone());
                 j += 2;
             }
             def_map
-        }
+        },
         _ => return Ok(None),
     };
 
@@ -221,7 +221,7 @@ async fn get_index_info(
             .collect(),
         Some(redis::Value::BulkString(bytes)) => {
             vec![String::from_utf8_lossy(bytes).to_string()]
-        }
+        },
         _ => Vec::new(),
     };
 
@@ -243,12 +243,12 @@ async fn get_index_info(
                         let k = match &attr_arr[j] {
                             redis::Value::BulkString(bytes) => {
                                 String::from_utf8_lossy(bytes).to_string()
-                            }
+                            },
                             redis::Value::SimpleString(s) => s.clone(),
                             _ => {
                                 j += 2;
                                 continue;
-                            }
+                            },
                         };
                         if k == "identifier" {
                             if let redis::Value::BulkString(bytes) = &attr_arr[j + 1] {
@@ -263,7 +263,7 @@ async fn get_index_info(
                 }
             }
             fields
-        }
+        },
         _ => Vec::new(),
     };
 

--- a/src/types/hash/batch_iter.rs
+++ b/src/types/hash/batch_iter.rs
@@ -349,7 +349,7 @@ impl HashBatchIterator {
                     Ok(Err(e)) => return Err(e),
                     Err(e) => {
                         return Err(Error::Runtime(format!("Task join error: {}", e)));
-                    }
+                    },
                 }
             }
 

--- a/src/types/hash/cluster_iter.rs
+++ b/src/types/hash/cluster_iter.rs
@@ -272,7 +272,7 @@ impl ClusterHashBatchIterator {
                     Ok(Err(e)) => return Err(e),
                     Err(e) => {
                         return Err(Error::Runtime(format!("Task join error: {}", e)));
-                    }
+                    },
                 }
             }
 

--- a/src/types/hash/convert.rs
+++ b/src/types/hash/convert.rs
@@ -117,7 +117,7 @@ fn build_int64_column(data: &[HashData], field_name: &str) -> Result<ArrayRef> {
                     ))
                 })?;
                 builder.append_value(parsed);
-            }
+            },
             Some(None) | None => builder.append_null(),
         }
     }
@@ -139,7 +139,7 @@ fn build_float64_column(data: &[HashData], field_name: &str) -> Result<ArrayRef>
                     ))
                 })?;
                 builder.append_value(parsed);
-            }
+            },
             Some(None) | None => builder.append_null(),
         }
     }
@@ -161,7 +161,7 @@ fn build_boolean_column(data: &[HashData], field_name: &str) -> Result<ArrayRef>
                     ))
                 })?;
                 builder.append_value(parsed);
-            }
+            },
             Some(None) | None => builder.append_null(),
         }
     }
@@ -185,7 +185,7 @@ fn build_date_column(data: &[HashData], field_name: &str) -> Result<ArrayRef> {
                     ))
                 })?;
                 builder.append_value(parsed);
-            }
+            },
             Some(None) | None => builder.append_null(),
         }
     }
@@ -209,7 +209,7 @@ fn build_datetime_column(data: &[HashData], field_name: &str) -> Result<ArrayRef
                     ))
                 })?;
                 builder.append_value(parsed);
-            }
+            },
             Some(None) | None => builder.append_null(),
         }
     }

--- a/src/types/json/batch_iter.rs
+++ b/src/types/json/batch_iter.rs
@@ -241,7 +241,7 @@ impl JsonBatchIterator {
                     Ok(Err(e)) => return Err(e),
                     Err(e) => {
                         return Err(Error::Runtime(format!("Task join error: {}", e)));
-                    }
+                    },
                 }
             }
 

--- a/src/types/json/cluster_iter.rs
+++ b/src/types/json/cluster_iter.rs
@@ -217,7 +217,7 @@ impl ClusterJsonBatchIterator {
                     Ok(Err(e)) => return Err(e),
                     Err(e) => {
                         return Err(Error::Runtime(format!("Task join error: {}", e)));
-                    }
+                    },
                 }
             }
 

--- a/src/types/json/convert.rs
+++ b/src/types/json/convert.rs
@@ -239,7 +239,7 @@ fn normalize_json_response(parsed: serde_json::Value) -> Option<serde_json::Valu
                 // Regular object, return as-is
                 Some(serde_json::Value::Object(map))
             }
-        }
+        },
 
         // Other types, return as-is
         other => Some(other),
@@ -369,14 +369,14 @@ fn build_int64_json_column(
                     } else {
                         builder.append_null();
                     }
-                }
+                },
                 Some(serde_json::Value::Null) | None => builder.append_null(),
                 Some(v) => {
                     return Err(Error::TypeConversion(format!(
                         "Cannot convert {:?} to i64 for field '{}'",
                         v, field_name
                     )));
-                }
+                },
             },
             None => builder.append_null(),
         }
@@ -400,14 +400,14 @@ fn build_float64_json_column(
                     } else {
                         builder.append_null();
                     }
-                }
+                },
                 Some(serde_json::Value::Null) | None => builder.append_null(),
                 Some(v) => {
                     return Err(Error::TypeConversion(format!(
                         "Cannot convert {:?} to f64 for field '{}'",
                         v, field_name
                     )));
-                }
+                },
             },
             None => builder.append_null(),
         }
@@ -432,7 +432,7 @@ fn build_boolean_json_column(
                         "Cannot convert {:?} to bool for field '{}'",
                         v, field_name
                     )));
-                }
+                },
             },
             None => builder.append_null(),
         }

--- a/src/types/string/batch_iter.rs
+++ b/src/types/string/batch_iter.rs
@@ -217,7 +217,7 @@ impl StringBatchIterator {
                     Ok(Err(e)) => return Err(e),
                     Err(e) => {
                         return Err(Error::Runtime(format!("Task join error: {}", e)));
-                    }
+                    },
                 }
             }
 

--- a/src/types/string/cluster_iter.rs
+++ b/src/types/string/cluster_iter.rs
@@ -195,7 +195,7 @@ impl ClusterStringBatchIterator {
                     Ok(Err(e)) => return Err(e),
                     Err(e) => {
                         return Err(Error::Runtime(format!("Task join error: {}", e)));
-                    }
+                    },
                 }
             }
 

--- a/src/types/string/convert.rs
+++ b/src/types/string/convert.rs
@@ -236,7 +236,7 @@ fn build_int64_column(data: &[StringData]) -> Result<ArrayRef> {
                     ))
                 })?;
                 builder.append_value(parsed);
-            }
+            },
             None => builder.append_null(),
         }
     }
@@ -258,7 +258,7 @@ fn build_float64_column(data: &[StringData]) -> Result<ArrayRef> {
                     ))
                 })?;
                 builder.append_value(parsed);
-            }
+            },
             None => builder.append_null(),
         }
     }
@@ -280,7 +280,7 @@ fn build_boolean_column(data: &[StringData]) -> Result<ArrayRef> {
                     ))
                 })?;
                 builder.append_value(parsed);
-            }
+            },
             None => builder.append_null(),
         }
     }
@@ -302,7 +302,7 @@ fn build_date_column(data: &[StringData]) -> Result<ArrayRef> {
                     ))
                 })?;
                 builder.append_value(parsed);
-            }
+            },
             None => builder.append_null(),
         }
     }
@@ -324,7 +324,7 @@ fn build_datetime_column(data: &[StringData]) -> Result<ArrayRef> {
                     ))
                 })?;
                 builder.append_value(parsed);
-            }
+            },
             None => builder.append_null(),
         }
     }

--- a/src/write.rs
+++ b/src/write.rs
@@ -444,7 +444,7 @@ async fn write_hashes_detailed_async(
                             });
                         }
                     }
-                }
+                },
                 Err(e) => {
                     // Entire pipeline failed - mark all keys as failed
                     for (key, _) in key_command_counts {
@@ -454,7 +454,7 @@ async fn write_hashes_detailed_async(
                             error: e.to_string(),
                         });
                     }
-                }
+                },
             }
         }
     }

--- a/tests/concurrency_tests.rs
+++ b/tests/concurrency_tests.rs
@@ -81,10 +81,10 @@ fn test_parallel_batch_reads_same_pattern() {
                     } else {
                         eprintln!("Thread {} got {} rows instead of 100", thread_id, count);
                     }
-                }
+                },
                 Err(e) => {
                     eprintln!("Thread {} failed: {}", thread_id, e);
-                }
+                },
             }
         });
 
@@ -593,10 +593,10 @@ fn test_high_concurrency_stress() {
                         while let Ok(Some(_)) = iterator.next_batch() {
                             read_ops.fetch_add(1, Ordering::SeqCst);
                         }
-                    }
+                    },
                     Err(_) => {
                         errors.fetch_add(1, Ordering::SeqCst);
-                    }
+                    },
                 }
             }
         });

--- a/tests/failure_mode_tests.rs
+++ b/tests/failure_mode_tests.rs
@@ -45,7 +45,7 @@ fn test_connection_error_message_quality() {
                 "Error message should be informative: {}",
                 err_msg
             );
-        }
+        },
     }
 }
 
@@ -67,7 +67,7 @@ fn test_invalid_url_error_message() {
                 "Error message should mention URL issue: {}",
                 err_msg
             );
-        }
+        },
     }
 }
 
@@ -345,7 +345,7 @@ fn test_key_type_changed_during_scan() {
     let mut error_count = 0;
     loop {
         match iterator.next_batch() {
-            Ok(Some(_)) => {}
+            Ok(Some(_)) => {},
             Ok(None) => break,
             Err(_) => {
                 error_count += 1;
@@ -353,7 +353,7 @@ fn test_key_type_changed_during_scan() {
                 if error_count > 5 {
                     break;
                 }
-            }
+            },
         }
     }
 
@@ -669,10 +669,10 @@ fn test_concurrent_failure_handling() {
                 match HashBatchIterator::new(&url, schema, config, None) {
                     Ok(_) => {
                         success_count.fetch_add(1, Ordering::SeqCst);
-                    }
+                    },
                     Err(_) => {
                         error_count.fetch_add(1, Ordering::SeqCst);
-                    }
+                    },
                 }
             })
         })
@@ -736,7 +736,7 @@ fn test_error_isolation_between_threads() {
                     Err(e) => {
                         results.lock().unwrap().push((i, Err(e.to_string())));
                         return;
-                    }
+                    },
                 };
 
                 let mut row_count = 0;
@@ -747,7 +747,7 @@ fn test_error_isolation_between_threads() {
                         Err(e) => {
                             results.lock().unwrap().push((i, Err(e.to_string())));
                             return;
-                        }
+                        },
                     }
                 }
 
@@ -770,9 +770,9 @@ fn test_error_isolation_between_threads() {
             Ok(count) if *thread_id != 0 => {
                 assert_eq!(*count, 10, "Thread {} should read all rows", thread_id);
                 success_threads += 1;
-            }
-            Ok(_) => {}  // Thread 0 might succeed with nulls
-            Err(_) => {} // Thread 0 might error
+            },
+            Ok(_) => {},  // Thread 0 might succeed with nulls
+            Err(_) => {}, // Thread 0 might error
         }
     }
 

--- a/tests/stress_tests.rs
+++ b/tests/stress_tests.rs
@@ -505,11 +505,11 @@ fn stress_continuous_scan_60s() {
                     total_rows_scanned += batch.num_rows();
                 }
                 iteration_count += 1;
-            }
+            },
             Err(e) => {
                 eprintln!("Error on iteration {}: {}", iteration_count, e);
                 errors += 1;
-            }
+            },
         }
 
         // Brief pause between iterations


### PR DESCRIPTION
Align polars-redis with Polars project conventions based on review of https://docs.pola.rs/development/contributing/

## Changes

### rustfmt.toml (#163)
Added Polars-compatible rustfmt settings:
- `match_block_trailing_comma = true`
- `use_field_init_shorthand = true`
- Documented nightly-only settings (`group_imports`, `imports_granularity`) as comments

### Clippy Lints (#165)
Added `[lints.clippy]` section to Cargo.toml:
- `collapsible_if = "allow"` to match Polars workspace settings

### Code Formatting
Applied rustfmt changes across 27 source files.

## Not Changed

### PyPolarsErr (#164)
Evaluated but decided to keep our current error handling approach. PyPolarsErr wraps PolarsError variants (ColumnNotFound, ComputeError, etc.) which don't map to our Redis-specific errors. Our current approach provides more semantically correct Python exceptions:
- Connection/InvalidUrl -> PyConnectionError
- KeyNotFound -> PyKeyError
- SchemaMismatch/TypeConversion -> PyValueError

Closes #162
Closes #163
Closes #165