### PR TITLE
docs: reorder RediSearch nav to show queries page first

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,8 +72,8 @@ nav:
       - Pub/Sub: guide/pubsub.md
       - Redis Streams: guide/streams.md
   - RediSearch:
-      - Index Management: guide/index-management.md
       - Queries & Aggregation: guide/redisearch.md
+      - Index Management: guide/index-management.md
       - Advanced Queries: examples/advanced-queries.md
   - Client Operations:
       - Overview: guide/client-operations.md


### PR DESCRIPTION
Reorders the RediSearch section in the navigation so that 'Queries & Aggregation' (with the high-level intro) appears before 'Index Management'.

This ensures users landing on the RediSearch section see the value proposition and overview first, rather than jumping straight into index creation details.