### PR TITLE
docs: split RediSearch guide into focused pages

### DIFF
--- a/docs/guide/redisearch-advanced.md
+++ b/docs/guide/redisearch-advanced.md
@@ -1,0 +1,217 @@
+# Advanced Search Options
+
+For fine-grained control over search behavior, use `SearchOptions`. This is useful for full-text search applications that need highlighting, summarization, or custom scoring.
+
+## SearchOptions
+
+```python
+from polars_redis.options import SearchOptions
+import polars_redis as pr
+
+opts = SearchOptions(
+    index="articles_idx",
+    query="python programming",
+    verbatim=True,           # Disable stemming
+    language="english",       # Stemming language
+    scorer="BM25",           # Scoring algorithm
+    dialect=4,               # RediSearch dialect
+)
+
+df = pr.search_hashes(
+    "redis://localhost:6379",
+    options=opts,
+    schema={"title": pl.Utf8, "body": pl.Utf8},
+).collect()
+```
+
+## Highlighting
+
+Wrap matching terms in custom tags for display:
+
+```python
+opts = SearchOptions(
+    index="articles_idx",
+    query="python",
+).with_highlight(
+    fields=["title", "body"],
+    open_tag="<em>",
+    close_tag="</em>",
+)
+
+df = pr.search_hashes(url, options=opts, schema=schema).collect()
+# Results have matching terms wrapped: "<em>Python</em> is a great language"
+```
+
+## Summarization
+
+Generate text snippets with matched terms (useful for search result previews):
+
+```python
+opts = SearchOptions(
+    index="articles_idx",
+    query="machine learning",
+).with_summarize(
+    fields=["body"],
+    frags=3,          # Number of fragments
+    len=30,           # Fragment length in words
+    separator="...",  # Between fragments
+)
+```
+
+## Relevance Scores
+
+Include relevance scores in results:
+
+```python
+opts = SearchOptions(
+    index="articles_idx",
+    query="python tutorial",
+).with_score(True, "_relevance")
+
+df = pr.search_hashes(url, options=opts, schema=schema).collect()
+# Results include _relevance column with BM25 scores
+```
+
+## Query Modifiers Reference
+
+| Option | Description |
+|--------|-------------|
+| `verbatim` | Disable stemming for exact term matching |
+| `no_stopwords` | Include stop words in the query |
+| `language` | Language for stemming (e.g., "english", "spanish", "french") |
+| `scorer` | Scoring function: "BM25", "TFIDF", "DISMAX" |
+| `expander` | Query expander: "SYNONYM" |
+| `slop` | Default slop for phrase queries |
+| `in_order` | Require phrase terms in order |
+| `dialect` | RediSearch dialect version (1-4) |
+
+## Filtering Options Reference
+
+| Option | Description |
+|--------|-------------|
+| `in_keys` | Limit search to specific document keys |
+| `in_fields` | Limit search to specific fields |
+| `timeout_ms` | Query timeout in milliseconds |
+
+## Smart Scan
+
+`smart_scan()` automatically detects whether a RediSearch index exists and optimizes query execution accordingly.
+
+### Basic Usage
+
+```python
+from polars_redis import smart_scan
+
+# Auto-detect index and use FT.SEARCH if available
+df = smart_scan(
+    url,
+    "user:*",
+    schema={"name": pl.Utf8, "age": pl.Int64},
+).filter(pl.col("age") > 30).collect()
+```
+
+If an index exists for the pattern, it uses FT.SEARCH. Otherwise, it falls back to SCAN.
+
+### Query Explanation
+
+See how a query will execute before running it:
+
+```python
+from polars_redis import explain_scan
+
+plan = explain_scan(url, "user:*", schema={"name": pl.Utf8})
+print(plan.explain())
+# Strategy: SEARCH
+# Index: users_idx
+#   Prefixes: user:
+#   Type: HASH
+# Server Query: *
+```
+
+### Execution Strategies
+
+| Strategy | When Used | Description |
+|----------|-----------|-------------|
+| **SEARCH** | Index found | Uses FT.SEARCH for server-side filtering |
+| **SCAN** | No index | Falls back to Redis SCAN |
+| **HYBRID** | Partial pushdown | FT.SEARCH + client-side filtering |
+
+### Index Discovery
+
+```python
+from polars_redis import list_indexes, find_index_for_pattern
+
+# List all RediSearch indexes
+indexes = list_indexes(url)
+for idx in indexes:
+    print(f"{idx.name}: prefixes={idx.prefixes}")
+
+# Find index for specific pattern
+idx = find_index_for_pattern(url, "user:*")
+if idx:
+    print(f"Found index: {idx.name}")
+```
+
+### Explicit Index Control
+
+```python
+# Use a specific index by name
+df = smart_scan(
+    url, "user:*",
+    schema={"name": pl.Utf8},
+    index="users_idx",
+    auto_detect_index=False,
+)
+
+# Use an Index object (auto-creates if needed)
+from polars_redis import Index, TextField, NumericField
+
+idx = Index(
+    name="users_idx",
+    prefix="user:",
+    schema=[TextField("name"), NumericField("age")],
+)
+
+df = smart_scan(url, "user:*", schema=schema, index=idx).collect()
+```
+
+### Graceful Degradation
+
+When RediSearch is unavailable, `smart_scan` falls back to SCAN without errors:
+
+```python
+# Works whether RediSearch is available or not
+df = smart_scan(url, "user:*", schema=schema).collect()
+```
+
+## search_hashes Parameters Reference
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `url` | str | required | Redis connection URL |
+| `index` | str | required | RediSearch index name |
+| `query` | str or Expr | `"*"` | Query string or expression |
+| `schema` | dict | required | Field names to Polars dtypes |
+| `include_key` | bool | `True` | Include Redis key as column |
+| `key_column_name` | str | `"_key"` | Name of key column |
+| `include_ttl` | bool | `False` | Include TTL as column |
+| `ttl_column_name` | str | `"_ttl"` | Name of TTL column |
+| `batch_size` | int | `1000` | Documents per batch |
+| `sort_by` | str | `None` | Field to sort by |
+| `sort_ascending` | bool | `True` | Sort direction |
+| `options` | SearchOptions | `None` | Advanced search options |
+
+## smart_scan Parameters Reference
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `url` | str | required | Redis connection URL |
+| `pattern` | str | `"*"` | Key pattern to match |
+| `schema` | dict | required | Field names to Polars dtypes |
+| `index` | str or Index | `None` | Force use of specific index |
+| `include_key` | bool | `True` | Include Redis key as column |
+| `key_column_name` | str | `"_key"` | Name of key column |
+| `include_ttl` | bool | `False` | Include TTL as column |
+| `ttl_column_name` | str | `"_ttl"` | Name of TTL column |
+| `batch_size` | int | `1000` | Documents per batch |
+| `auto_detect_index` | bool | `True` | Auto-detect matching indexes |

--- a/docs/guide/redisearch-aggregation.md
+++ b/docs/guide/redisearch-aggregation.md
@@ -1,0 +1,235 @@
+# Aggregation
+
+`aggregate_hashes()` uses RediSearch's FT.AGGREGATE for server-side grouping and aggregation. Only aggregated results transfer - not raw documents.
+
+!!! tip "Setup"
+    Examples on this page use the test data from [RediSearch Overview](redisearch.md#setup-test-data).
+
+## Basic Aggregation
+
+```python
+import polars_redis as pr
+
+url = "redis://localhost:6379"
+
+# Count employees by department
+df = pr.aggregate_hashes(
+    url,
+    index="employees_idx",
+    query="*",
+    group_by=["@department"],
+    reduce=[("COUNT", [], "employee_count")],
+)
+
+print(df)
+# shape: (3, 2)
+# +-------------+----------------+
+# | department  | employee_count |
+# | ---         | ---            |
+# | str         | i64            |
+# +=============+================+
+# | engineering | 4              |
+# | product     | 2              |
+# | marketing   | 2              |
+# +-------------+----------------+
+```
+
+## Multiple Reduce Functions
+
+```python
+# Salary statistics by department
+df = pr.aggregate_hashes(
+    url,
+    index="employees_idx",
+    query="@status:{active}",  # Filter before aggregating
+    group_by=["@department"],
+    reduce=[
+        ("COUNT", [], "headcount"),
+        ("AVG", ["@salary"], "avg_salary"),
+        ("MIN", ["@salary"], "min_salary"),
+        ("MAX", ["@salary"], "max_salary"),
+        ("SUM", ["@salary"], "total_payroll"),
+    ],
+)
+```
+
+## Global Aggregation
+
+Aggregate without grouping for overall statistics:
+
+```python
+# Company-wide stats
+df = pr.aggregate_hashes(
+    url,
+    index="employees_idx",
+    query="@status:{active}",
+    reduce=[
+        ("COUNT", [], "total_employees"),
+        ("AVG", ["@salary"], "company_avg_salary"),
+        ("AVG", ["@age"], "avg_age"),
+    ],
+)
+
+print(df)
+# shape: (1, 3)
+# +-----------------+--------------------+---------+
+# | total_employees | company_avg_salary | avg_age |
+# | ---             | ---                | ---     |
+# | i64             | f64                | f64     |
+# +=================+====================+=========+
+# | 6               | 114166.67          | 37.33   |
+# +-----------------+--------------------+---------+
+```
+
+## Computed Fields with APPLY
+
+Create derived fields using expressions:
+
+```python
+df = pr.aggregate_hashes(
+    url,
+    index="employees_idx",
+    query="*",
+    group_by=["@department"],
+    reduce=[
+        ("SUM", ["@salary"], "total_salary"),
+        ("COUNT", [], "count"),
+    ],
+    apply=[
+        ("@total_salary / @count", "calculated_avg"),
+    ],
+)
+```
+
+## Post-Aggregation Filtering
+
+Filter results after aggregation (like SQL's HAVING):
+
+```python
+# Only departments with more than 2 employees
+df = pr.aggregate_hashes(
+    url,
+    index="employees_idx",
+    query="*",
+    group_by=["@department"],
+    reduce=[("COUNT", [], "count")],
+    filter_expr="@count > 2",
+)
+```
+
+## Sorting and Pagination
+
+```python
+# Top 3 departments by average salary
+df = pr.aggregate_hashes(
+    url,
+    index="employees_idx",
+    query="*",
+    group_by=["@department"],
+    reduce=[("AVG", ["@salary"], "avg_salary")],
+    sort_by=[("@avg_salary", False)],  # False = descending
+    limit=3,
+    offset=0,
+)
+```
+
+## Loading Additional Fields
+
+Load specific fields before aggregation:
+
+```python
+df = pr.aggregate_hashes(
+    url,
+    index="employees_idx",
+    query="*",
+    load=["@name", "@salary"],  # Load these fields
+    group_by=["@department"],
+    reduce=[
+        ("FIRST_VALUE", ["@name"], "sample_employee"),
+        ("AVG", ["@salary"], "avg_salary"),
+    ],
+)
+```
+
+## Parameters Reference
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `url` | str | required | Redis connection URL |
+| `index` | str | required | RediSearch index name |
+| `query` | str | `"*"` | Filter query before aggregation |
+| `group_by` | list | `None` | Fields to group by (with @ prefix) |
+| `reduce` | list | `None` | Reduce operations as (function, args, alias) tuples |
+| `apply` | list | `None` | Computed expressions as (expression, alias) tuples |
+| `filter_expr` | str | `None` | Post-aggregation filter |
+| `sort_by` | list | `None` | Sort by (field, ascending) tuples |
+| `limit` | int | `None` | Maximum results |
+| `offset` | int | `0` | Skip first N results |
+| `load` | list | `None` | Fields to load before aggregation |
+
+## Reduce Functions Reference
+
+| Function | Args | Description |
+|----------|------|-------------|
+| `COUNT` | `[]` | Count documents in group |
+| `SUM` | `["@field"]` | Sum of numeric field |
+| `AVG` | `["@field"]` | Average of numeric field |
+| `MIN` | `["@field"]` | Minimum value |
+| `MAX` | `["@field"]` | Maximum value |
+| `FIRST_VALUE` | `["@field"]` | First value in group |
+| `TOLIST` | `["@field"]` | Collect all values as list |
+| `QUANTILE` | `["@field", "0.5"]` | Quantile (0.5 = median) |
+| `STDDEV` | `["@field"]` | Standard deviation |
+| `COUNT_DISTINCT` | `["@field"]` | Count unique values |
+| `COUNT_DISTINCTISH` | `["@field"]` | Approximate distinct count (faster) |
+
+## Example: Analytics Dashboard
+
+```python
+import polars as pl
+import polars_redis as pr
+from polars_redis import col
+
+url = "redis://localhost:6379"
+
+# 1. Filter: active engineers
+engineers = pr.search_hashes(
+    url,
+    index="employees_idx",
+    query=(col("department") == "engineering") & (col("status") == "active"),
+    schema={"name": pl.Utf8, "age": pl.Int64, "salary": pl.Float64},
+).collect()
+
+# 2. Aggregate: salary distribution by department
+salary_stats = pr.aggregate_hashes(
+    url,
+    index="employees_idx",
+    query="@status:{active}",
+    group_by=["@department"],
+    reduce=[
+        ("COUNT", [], "headcount"),
+        ("AVG", ["@salary"], "avg_salary"),
+        ("STDDEV", ["@salary"], "salary_stddev"),
+        ("MIN", ["@salary"], "min_salary"),
+        ("MAX", ["@salary"], "max_salary"),
+    ],
+    sort_by=[("@headcount", False)],
+)
+
+# 3. Aggregate: age distribution
+age_stats = pr.aggregate_hashes(
+    url,
+    index="employees_idx",
+    query="*",
+    reduce=[
+        ("AVG", ["@age"], "avg_age"),
+        ("MIN", ["@age"], "youngest"),
+        ("MAX", ["@age"], "oldest"),
+        ("QUANTILE", ["@age", "0.5"], "median_age"),
+    ],
+)
+
+print("Engineers:", engineers)
+print("Salary by dept:", salary_stats)
+print("Age stats:", age_stats)
+```

--- a/docs/guide/redisearch-queries.md
+++ b/docs/guide/redisearch-queries.md
@@ -1,0 +1,376 @@
+# Query Builder
+
+polars-redis provides a Polars-like query builder that generates RediSearch queries. This gives you a familiar, composable API without learning RediSearch query syntax.
+
+!!! tip "Setup"
+    Examples on this page use the test data from [RediSearch Overview](redisearch.md#setup-test-data).
+
+## Basic Operations
+
+### Comparisons
+
+```python
+from polars_redis import col
+
+# Numeric comparisons
+query = col("age") > 30       # @age:[(30 +inf]
+query = col("age") >= 30      # @age:[30 +inf]
+query = col("age") < 30       # @age:[-inf (30]
+query = col("age") <= 30      # @age:[-inf 30]
+
+# Equality (tags)
+query = col("status") == "active"    # @status:{active}
+query = col("status") != "inactive"  # -@status:{inactive}
+```
+
+### Combining Conditions
+
+```python
+# AND (both must match)
+query = (col("age") > 30) & (col("status") == "active")
+# (@age:[(30 +inf]) (@status:{active})
+
+# OR (either matches)
+query = (col("department") == "engineering") | (col("department") == "product")
+# (@department:{engineering}) | (@department:{product})
+
+# Negation
+query = ~(col("status") == "inactive")
+# -(@status:{inactive})
+```
+
+### Raw Queries
+
+For RediSearch features not covered by the builder, use `raw()`:
+
+```python
+from polars_redis import raw
+
+# Full-text search
+query = raw("@name:alice")
+
+# Prefix search
+query = raw("@name:ali*")
+
+# Combine raw with builder
+query = raw("@name:alice") & (col("age") > 25)
+```
+
+## Text Search
+
+### Full-text Search
+
+```python
+# Basic text search (with stemming)
+query = col("title").contains("python")
+# @title:python
+
+# Prefix matching
+query = col("name").starts_with("jo")
+# @name:jo*
+
+# Suffix matching
+query = col("name").ends_with("son")
+# @name:*son
+
+# Substring/infix matching
+query = col("description").contains_substring("data")
+# @description:*data*
+```
+
+### Fuzzy Matching
+
+Match terms with typos using Levenshtein distance (1-3):
+
+```python
+# Allow 1 character difference
+query = col("title").fuzzy("python", distance=1)
+# @title:%python%
+
+# Allow 2 character differences
+query = col("title").fuzzy("algorithm", distance=2)
+# @title:%%algorithm%%
+```
+
+### Phrase Search
+
+Search for phrases with optional slop and order control:
+
+```python
+# Exact phrase (words must appear consecutively)
+query = col("title").phrase("hello", "world")
+# @title:(hello world)
+
+# Allow words between (slop = max intervening terms)
+query = col("title").phrase("machine", "learning", slop=2)
+# @title:(machine learning) => { $slop: 2; }
+
+# Require in-order with slop
+query = col("title").phrase("data", "science", slop=3, inorder=True)
+# @title:(data science) => { $slop: 3; $inorder: true; }
+```
+
+### Wildcard Matching
+
+```python
+# Simple wildcard
+query = col("name").matches("j*n")
+# @name:j*n
+
+# Exact wildcard matching
+query = col("code").matches_exact("FOO*BAR?")
+# @code:"w'FOO*BAR?'"
+```
+
+### Multi-field Search
+
+Search across multiple fields simultaneously:
+
+```python
+from polars_redis import cols
+
+# Search title and body together
+query = cols("title", "body").contains("python")
+# @title|body:python
+
+# Prefix search across fields
+query = cols("first_name", "last_name").starts_with("john")
+# @first_name|last_name:john*
+```
+
+## Tag Operations
+
+```python
+# Single tag match
+query = col("category").has_tag("electronics")
+# @category:{electronics}
+
+# Match any of multiple tags
+query = col("tags").has_any_tag(["urgent", "important"])
+# @tags:{urgent|important}
+```
+
+## Geo Search
+
+### Radius Search
+
+```python
+# Find locations within 10km of a point
+query = col("location").within_radius(-122.4194, 37.7749, 10, "km")
+# @location:[-122.4194 37.7749 10 km]
+
+# Supported units: m, km, mi, ft
+query = col("location").within_radius(-73.9857, 40.7484, 5, "mi")
+```
+
+### Polygon Search
+
+```python
+# Define polygon as list of (lon, lat) points
+polygon = [
+    (-122.5, 37.7),
+    (-122.5, 37.8),
+    (-122.3, 37.8),
+    (-122.3, 37.7),
+    (-122.5, 37.7),  # Close the polygon
+]
+query = col("location").within_polygon(polygon)
+# @location:[WITHIN $poly]
+```
+
+!!! note
+    Polygon queries require passing the polygon as a query parameter. The query builder generates a parameterized query.
+
+## Vector Search
+
+For semantic similarity search with vector embeddings:
+
+### K-Nearest Neighbors (KNN)
+
+```python
+# Find 10 most similar documents
+query = col("embedding").knn(10, "query_vec")
+# *=>[KNN 10 @embedding $query_vec]
+
+# Use with search_hashes (pass vector as parameter)
+df = search_hashes(
+    url,
+    index="docs_idx",
+    query=query,
+    schema={"title": pl.Utf8, "embedding": pl.List(pl.Float32)},
+    params={"query_vec": embedding_bytes},
+)
+```
+
+### Vector Range Search
+
+```python
+# Find all documents within distance 0.5
+query = col("embedding").vector_range(0.5, "query_vec")
+# @embedding:[VECTOR_RANGE 0.5 $query_vec]
+```
+
+## Relevance Tuning
+
+### Boosting
+
+Increase the relevance score contribution of specific terms:
+
+```python
+# Boost title matches 2x
+query = col("title").contains("python").boost(2.0)
+# (@title:python) => { $weight: 2.0; }
+
+# Combine with other terms
+title_query = col("title").contains("python").boost(2.0)
+body_query = col("body").contains("python")
+query = title_query | body_query
+```
+
+### Optional Terms
+
+Mark terms as optional for better ranking without requiring them:
+
+```python
+# Documents with "python" required, "tutorial" optional but preferred
+required = col("title").contains("python")
+optional = col("title").contains("tutorial").optional()
+query = required & optional
+# @title:python ~@title:tutorial
+```
+
+## Null Checks
+
+```python
+# Find documents missing a field
+query = col("email").is_null()
+# ismissing(@email)
+
+# Find documents with a field present
+query = col("email").is_not_null()
+# -ismissing(@email)
+```
+
+## Debugging
+
+Use `to_redis()` to inspect the generated RediSearch query:
+
+```python
+query = (col("type") == "eBikes") & (col("price") < 1000)
+print(query.to_redis())
+# @type:{eBikes} @price:[-inf (1000]
+```
+
+## Operations Reference
+
+| Operation | Example | RediSearch Output |
+|-----------|---------|-------------------|
+| Equal | `col("status") == "active"` | `@status:{active}` |
+| Not Equal | `col("status") != "active"` | `-@status:{active}` |
+| Greater Than | `col("age") > 30` | `@age:[(30 +inf]` |
+| Greater or Equal | `col("age") >= 30` | `@age:[30 +inf]` |
+| Less Than | `col("age") < 30` | `@age:[-inf (30]` |
+| Less or Equal | `col("age") <= 30` | `@age:[-inf 30]` |
+| And | `expr1 & expr2` | `(expr1) (expr2)` |
+| Or | `expr1 \| expr2` | `(expr1) \| (expr2)` |
+| Negate | `~expr` or `expr.negate()` | `-(...expr...)` |
+| Contains | `col("title").contains("word")` | `@title:word` |
+| Starts With | `col("name").starts_with("jo")` | `@name:jo*` |
+| Ends With | `col("name").ends_with("son")` | `@name:*son` |
+| Fuzzy | `col("name").fuzzy("john", 1)` | `@name:%john%` |
+| Tag Match | `col("cat").has_tag("x")` | `@cat:{x}` |
+| Tag Any | `col("cat").has_any_tag(["x","y"])` | `@cat:{x\|y}` |
+| Geo Radius | `col("loc").within_radius(lon, lat, r, "km")` | `@loc:[lon lat r km]` |
+| KNN | `col("vec").knn(10, "param")` | `*=>[KNN 10 @vec $param]` |
+| Boost | `expr.boost(2.0)` | `(expr) => { $weight: 2.0; }` |
+| Optional | `expr.optional()` | `~(expr)` |
+| Is Null | `col("field").is_null()` | `ismissing(@field)` |
+
+## Client-Side Filters
+
+Some operations can't be pushed to RediSearch. These fetch data first, then filter in Polars. Use them when RediSearch doesn't support the operation you need.
+
+!!! warning "Performance"
+    Client-side filters transfer all matching documents before filtering. Combine with server-side filters when possible to reduce data transfer.
+
+### Regex Matching
+
+```python
+# Match email patterns (runs in Polars)
+query = col("email").matches_regex(r".*@gmail\.com$")
+
+# Combine with server-side filter for efficiency
+query = (col("status") == "active") & col("email").matches_regex(r".*@company\.com")
+# Server filters by status first, then Polars filters by regex
+```
+
+### Case-Insensitive Matching
+
+```python
+# Case-insensitive contains
+query = col("name").icontains("john")
+
+# Case-insensitive equality
+query = col("department").iequals("ENGINEERING")
+```
+
+### Multiple Substring Matching
+
+```python
+# Match any of multiple substrings
+query = col("description").contains_any(["python", "rust", "go"])
+```
+
+### String Similarity
+
+```python
+# Find names similar to "john" (80% similarity threshold)
+query = col("name").similar_to("john", threshold=0.8)
+```
+
+### Date/Time Operations
+
+```python
+# Date comparisons
+query = col("created_at").as_date() > "2024-01-01"
+query = col("updated_at").as_datetime() >= "2024-06-15T12:00:00"
+
+# Date part extraction
+query = col("birth_date").as_date().year() == 1990
+query = col("created_at").as_date().month().is_in([1, 2, 3])  # Q1
+query = col("event_time").as_datetime().hour() >= 9
+
+# Available date parts: year(), month(), day(), weekday(), hour(), minute()
+```
+
+### Array/JSON Operations
+
+```python
+# Check if array contains value
+query = col("tags").array_contains("python")
+
+# Filter by array length
+query = col("items").array_len() > 5
+
+# Extract nested JSON value
+query = col("metadata").json_path("$.user.role") == "admin"
+```
+
+### Hybrid Execution
+
+When queries combine server-side and client-side operations, polars-redis automatically splits execution:
+
+```python
+# This query has both server-pushable and client-side parts
+query = (col("age") > 30) & col("email").matches_regex(r".*@gmail\.com")
+
+# Check what runs where
+print(query.is_client_side)  # True
+
+# View execution plan
+print(query.explain())
+# RediSearch: @age:[(30 +inf]
+# Polars filter: pl.col("email").str.contains(r".*@gmail\.com")
+```
+
+The query builder automatically optimizes for minimum data transfer by pushing what it can to RediSearch.

--- a/docs/guide/redisearch.md
+++ b/docs/guide/redisearch.md
@@ -1,4 +1,4 @@
-# RediSearch Integration
+# RediSearch Overview
 
 ## Why RediSearch?
 
@@ -14,6 +14,88 @@ With polars-redis + RediSearch, you can:
 
 The result? **90%+ reduction in data transfer** for selective queries.
 
+## When to Use RediSearch
+
+RediSearch shines when:
+
+- You have **10K+ documents** and selective queries (filtering returns <50% of data)
+- You need **server-side aggregation** (GROUP BY, COUNT, AVG, SUM)
+- You want **full-text search** with stemming, fuzzy matching, or phrase queries
+- You need **geo queries** (find within radius/polygon)
+- You're doing **vector similarity search**
+
+## When NOT to Use RediSearch
+
+Skip RediSearch and use `scan_hashes()` + Polars filtering when:
+
+- **Small datasets** (<10K documents) - scanning is fast enough
+- **One-off exploratory queries** - creating an index isn't worth it
+- **You need all or most of the data** - no filtering benefit
+- **Complex transforms** that Polars handles better than RediSearch
+
+```python
+# For small datasets, this is often simpler and fast enough
+df = scan_hashes(url, "user:*", schema).filter(
+    pl.col("age") > 30
+).collect()
+```
+
+## Setup: Test Data
+
+To follow along with examples in this guide, set up sample data:
+
+```python
+import polars as pl
+import polars_redis as pr
+from polars_redis import Index, TextField, NumericField, TagField
+
+url = "redis://localhost:6379"
+
+# Create sample employees
+df = pl.DataFrame({
+    "id": [1, 2, 3, 4, 5, 6, 7, 8],
+    "name": ["Alice", "Bob", "Carol", "Dave", "Eve", "Frank", "Grace", "Henry"],
+    "age": [32, 28, 45, 35, 29, 52, 38, 41],
+    "department": ["engineering", "engineering", "product", "product", 
+                   "marketing", "engineering", "marketing", "engineering"],
+    "salary": [120000, 95000, 140000, 110000, 85000, 150000, 95000, 130000],
+    "status": ["active", "active", "active", "inactive", "active", 
+               "active", "active", "inactive"],
+})
+
+# Write to Redis
+pr.write_hashes(df, url, key_column="id", key_prefix="employee:")
+
+# Create index
+idx = Index(
+    name="employees_idx",
+    prefix="employee:",
+    schema=[
+        TextField("name", sortable=True),
+        NumericField("age", sortable=True),
+        TagField("department"),
+        NumericField("salary", sortable=True),
+        TagField("status"),
+    ]
+)
+idx.ensure_exists(url)
+
+print("Created 8 employees and index")
+```
+
+## Prerequisites
+
+RediSearch requires Redis Stack or Redis with the RediSearch module:
+
+```bash
+# Start Redis Stack (includes RediSearch)
+docker run -d -p 6379:6379 redis/redis-stack:latest
+
+# Verify RediSearch is available
+redis-cli MODULE LIST
+# Should include "search"
+```
+
 ## Two Ways to Query
 
 You can write queries using **native RediSearch syntax** or the **polars-redis query builder**:
@@ -27,8 +109,8 @@ You can write queries using **native RediSearch syntax** or the **polars-redis q
     query = (col("age") > 30) & (col("status") == "active")
     
     df = search_hashes(
-        "redis://localhost:6379",
-        index="users_idx",
+        url,
+        index="employees_idx",
         query=query,
         schema={"name": pl.Utf8, "age": pl.Int64},
     ).collect()
@@ -39,8 +121,8 @@ You can write queries using **native RediSearch syntax** or the **polars-redis q
     ```python
     # Native RediSearch query string
     df = search_hashes(
-        "redis://localhost:6379",
-        index="users_idx",
+        url,
+        index="employees_idx",
         query="@age:[(30 +inf] @status:{active}",
         schema={"name": pl.Utf8, "age": pl.Int64},
     ).collect()
@@ -48,852 +130,119 @@ You can write queries using **native RediSearch syntax** or the **polars-redis q
 
 The query builder generates valid RediSearch queries while giving you a familiar, composable API. Use `query.to_redis()` anytime to see the generated query string.
 
-## Prerequisites
-
-RediSearch requires:
-
-- Redis Stack or Redis with RediSearch module
-- An existing index on your data (or use polars-redis to create one)
-
-```bash
-# Start Redis Stack
-docker run -d -p 6379:6379 redis/redis-stack:latest
-
-# Verify RediSearch is available
-redis-cli MODULE LIST
-# Should include "search"
-```
-
-## Creating an Index
-
-Before using `search_hashes()` or `aggregate_hashes()`, you need an index. polars-redis provides typed helpers for creating indexes:
-
-```python
-from polars_redis import Index, TextField, NumericField, TagField
-
-idx = Index(
-    name="users_idx",
-    prefix="user:",
-    schema=[
-        TextField("name", sortable=True),
-        NumericField("age", sortable=True),
-        TagField("department"),
-        NumericField("salary"),
-        TagField("status"),
-    ]
-)
-
-# Create the index
-idx.create("redis://localhost:6379")
-
-# Or ensure it exists (idempotent)
-idx.ensure_exists("redis://localhost:6379")
-```
-
-You can also pass the `Index` object directly to `search_hashes()` for auto-creation:
-
-```python
-df = search_hashes(
-    "redis://localhost:6379",
-    index=idx,  # Auto-creates if not exists
-    query=col("age") > 30,
-    schema={"name": pl.Utf8, "age": pl.Int64},
-).collect()
-```
-
-!!! tip "Index Management"
-    See [Index Management](index-management.md) for complete documentation on field types, schema inference, validation, and migration.
-
-## Searching with search_hashes()
+## Basic Search
 
 `search_hashes()` uses RediSearch FT.SEARCH to filter data server-side:
 
 ```python
 import polars as pl
-import polars_redis as redis
-
-# Basic search with raw query string
-df = redis.search_hashes(
-    "redis://localhost:6379",
-    index="users_idx",
-    query="@age:[30 +inf]",  # RediSearch query syntax
-    schema={"name": pl.Utf8, "age": pl.Int64, "department": pl.Utf8},
-).collect()
-```
-
-### Parameters
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `url` | str | required | Redis connection URL |
-| `index` | str | required | RediSearch index name |
-| `query` | str or Expr | `"*"` | Query string or expression |
-| `schema` | dict | required | Field names to Polars dtypes |
-| `include_key` | bool | `True` | Include Redis key as column |
-| `key_column_name` | str | `"_key"` | Name of key column |
-| `include_ttl` | bool | `False` | Include TTL as column |
-| `ttl_column_name` | str | `"_ttl"` | Name of TTL column |
-| `batch_size` | int | `1000` | Documents per batch |
-| `sort_by` | str | `None` | Field to sort by |
-| `sort_ascending` | bool | `True` | Sort direction |
-
-## Query Builder
-
-polars-redis provides a Polars-like query builder that generates RediSearch queries:
-
-```python
-from polars_redis import col
-
-# Simple comparison
-query = col("age") > 30
-# Generates: @age:[(30 +inf]
-
-# Equality
-query = col("status") == "active"
-# Generates: @status:{active}
-
-# Combining conditions
-query = (col("age") > 30) & (col("department") == "engineering")
-# Generates: (@age:[(30 +inf]) (@department:{engineering})
-
-# Or conditions
-query = (col("status") == "active") | (col("status") == "pending")
-# Generates: (@status:{active}) | (@status:{pending})
-
-# Negation
-query = col("status") != "inactive"
-# Generates: -@status:{inactive}
-
-# Use in search
-df = redis.search_hashes(
-    "redis://localhost:6379",
-    index="users_idx",
-    query=query,
-    schema={"name": pl.Utf8, "age": pl.Int64, "status": pl.Utf8},
-).collect()
-```
-
-### Supported Operations
-
-| Operation | Example | RediSearch Output |
-|-----------|---------|-------------------|
-| Equal | `col("status") == "active"` | `@status:{active}` |
-| Not Equal | `col("status") != "active"` | `-@status:{active}` |
-| Greater Than | `col("age") > 30` | `@age:[(30 +inf]` |
-| Greater or Equal | `col("age") >= 30` | `@age:[30 +inf]` |
-| Less Than | `col("age") < 30` | `@age:[-inf (30]` |
-| Less or Equal | `col("age") <= 30` | `@age:[-inf 30]` |
-| And | `expr1 & expr2` | `(expr1) (expr2)` |
-| Or | `expr1 \| expr2` | `(expr1) \| (expr2)` |
-| Negate | `expr.negate()` | `-(...expr...)` |
-
-### Raw Queries
-
-For complex queries, use `raw()`:
-
-```python
-from polars_redis import raw
-
-# Full-text search
-query = raw("@name:alice")
-
-# Prefix search
-query = raw("@name:ali*")
-
-# Combine raw with builder
-query = raw("@name:alice") & (col("age") > 25)
-```
-
-## Advanced Query Features
-
-### Text Search
-
-#### Full-text Search
-
-```python
-# Basic text search (with stemming)
-query = col("title").contains("python")
-# @title:python
-
-# Prefix matching
-query = col("name").starts_with("jo")
-# @name:jo*
-
-# Suffix matching
-query = col("name").ends_with("son")
-# @name:*son
-
-# Substring/infix matching
-query = col("description").contains_substring("data")
-# @description:*data*
-```
-
-#### Fuzzy Matching
-
-Match terms with typos using Levenshtein distance (1-3):
-
-```python
-# Allow 1 character difference
-query = col("title").fuzzy("python", distance=1)
-# @title:%python%
-
-# Allow 2 character differences
-query = col("title").fuzzy("algorithm", distance=2)
-# @title:%%algorithm%%
-```
-
-#### Phrase Search
-
-Search for phrases with optional slop and order control:
-
-```python
-# Exact phrase (words must appear consecutively)
-query = col("title").phrase("hello", "world")
-# @title:(hello world)
-
-# Allow words between (slop = max intervening terms)
-query = col("title").phrase("machine", "learning", slop=2)
-# @title:(machine learning) => { $slop: 2; }
-
-# Require in-order with slop
-query = col("title").phrase("data", "science", slop=3, inorder=True)
-# @title:(data science) => { $slop: 3; $inorder: true; }
-```
-
-#### Wildcard Matching
-
-```python
-# Simple wildcard
-query = col("name").matches("j*n")
-# @name:j*n
-
-# Exact wildcard matching
-query = col("code").matches_exact("FOO*BAR?")
-# @code:"w'FOO*BAR?'"
-```
-
-### Multi-field Search
-
-Search across multiple fields simultaneously:
-
-```python
-from polars_redis import cols
-
-# Search title and body together
-query = cols("title", "body").contains("python")
-# @title|body:python
-
-# Prefix search across fields
-query = cols("first_name", "last_name").starts_with("john")
-# @first_name|last_name:john*
-```
-
-### Tag Operations
-
-```python
-# Single tag match
-query = col("category").has_tag("electronics")
-# @category:{electronics}
-
-# Match any of multiple tags
-query = col("tags").has_any_tag(["urgent", "important"])
-# @tags:{urgent|important}
-```
-
-### Geo Search
-
-#### Radius Search
-
-```python
-# Find locations within 10km of a point
-query = col("location").within_radius(-122.4194, 37.7749, 10, "km")
-# @location:[-122.4194 37.7749 10 km]
-
-# Supported units: m, km, mi, ft
-query = col("location").within_radius(-73.9857, 40.7484, 5, "mi")
-```
-
-#### Polygon Search
-
-Search within a polygon boundary:
-
-```python
-# Define polygon as list of (lon, lat) points
-polygon = [
-    (-122.5, 37.7),
-    (-122.5, 37.8),
-    (-122.3, 37.8),
-    (-122.3, 37.7),
-    (-122.5, 37.7),  # Close the polygon
-]
-query = col("location").within_polygon(polygon)
-# @location:[WITHIN $poly]
-```
-
-!!! note
-    Polygon queries require passing the polygon as a query parameter. The query builder generates a parameterized query.
-
-### Vector Search
-
-For semantic similarity search with vector embeddings:
-
-#### K-Nearest Neighbors (KNN)
-
-```python
-# Find 10 most similar documents
-query = col("embedding").knn(10, "query_vec")
-# *=>[KNN 10 @embedding $query_vec]
-
-# Use with search_hashes (pass vector as parameter)
-df = redis.search_hashes(
-    url,
-    index="docs_idx",
-    query=query,
-    schema={"title": pl.Utf8, "embedding": pl.List(pl.Float32)},
-    params={"query_vec": embedding_bytes},
-)
-```
-
-#### Vector Range Search
-
-Find all vectors within a distance threshold:
-
-```python
-# Find all documents within distance 0.5
-query = col("embedding").vector_range(0.5, "query_vec")
-# @embedding:[VECTOR_RANGE 0.5 $query_vec]
-```
-
-### Relevance Tuning
-
-#### Boosting
-
-Increase the relevance score contribution of specific terms:
-
-```python
-# Boost title matches 2x
-query = col("title").contains("python").boost(2.0)
-# (@title:python) => { $weight: 2.0; }
-
-# Combine with other terms
-title_query = col("title").contains("python").boost(2.0)
-body_query = col("body").contains("python")
-query = title_query | body_query
-```
-
-#### Optional Terms
-
-Mark terms as optional for better ranking without requiring them:
-
-```python
-# Documents with "python" required, "tutorial" optional but preferred
-required = col("title").contains("python")
-optional = col("title").contains("tutorial").optional()
-query = required & optional
-# @title:python ~@title:tutorial
-```
-
-### Null Checks
-
-```python
-# Find documents missing a field
-query = col("email").is_null()
-# ismissing(@email)
-
-# Find documents with a field present
-query = col("email").is_not_null()
-# -ismissing(@email)
-```
-
-### Debugging Queries
-
-Use `to_redis()` to inspect the generated RediSearch query:
-
-```python
-query = (col("type") == "eBikes") & (col("price") < 1000)
-print(query.to_redis())
-# @type:{eBikes} @price:[-inf (1000]
-```
-
-!!! tip "More Examples"
-    See [Advanced Query Examples](../examples/advanced-queries.md) for real-world use cases including vector search, geo filtering, fuzzy matching, and dynamic query building.
-
-## Aggregation with aggregate_hashes()
-
-`aggregate_hashes()` uses FT.AGGREGATE for server-side grouping and aggregation:
-
-```python
-# Group by department and calculate statistics
-df = redis.aggregate_hashes(
-    "redis://localhost:6379",
-    index="users_idx",
-    query="*",
-    group_by=["@department"],
-    reduce=[
-        ("COUNT", [], "employee_count"),
-        ("AVG", ["@salary"], "avg_salary"),
-        ("SUM", ["@salary"], "total_payroll"),
-    ],
-)
-```
-
-### Parameters
-
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `url` | str | required | Redis connection URL |
-| `index` | str | required | RediSearch index name |
-| `query` | str | `"*"` | Filter query before aggregation |
-| `group_by` | list | `None` | Fields to group by (with @ prefix) |
-| `reduce` | list | `None` | Reduce operations (function, args, alias) |
-| `apply` | list | `None` | Computed expressions (expression, alias) |
-| `filter_expr` | str | `None` | Post-aggregation filter |
-| `sort_by` | list | `None` | Sort by (field, ascending) tuples |
-| `limit` | int | `None` | Maximum results |
-| `offset` | int | `0` | Skip first N results |
-| `load` | list | `None` | Fields to load before aggregation |
-
-### Reduce Functions
-
-| Function | Args | Description |
-|----------|------|-------------|
-| `COUNT` | `[]` | Count documents |
-| `SUM` | `["@field"]` | Sum of values |
-| `AVG` | `["@field"]` | Average of values |
-| `MIN` | `["@field"]` | Minimum value |
-| `MAX` | `["@field"]` | Maximum value |
-| `FIRST_VALUE` | `["@field"]` | First value |
-| `TOLIST` | `["@field"]` | Collect as list |
-| `QUANTILE` | `["@field", "0.5"]` | Quantile (e.g., median) |
-| `STDDEV` | `["@field"]` | Standard deviation |
-
-### Computed Fields with APPLY
-
-```python
-df = redis.aggregate_hashes(
-    "redis://localhost:6379",
-    index="sales_idx",
-    query="*",
-    group_by=["@region"],
-    reduce=[
-        ("SUM", ["@revenue"], "total_revenue"),
-        ("COUNT", [], "order_count"),
-    ],
-    apply=[
-        ("@total_revenue / @order_count", "avg_order_value"),
-    ],
-)
-```
-
-### Post-Aggregation Filtering
-
-```python
-df = redis.aggregate_hashes(
-    "redis://localhost:6379",
-    index="users_idx",
-    query="*",
-    group_by=["@department"],
-    reduce=[("COUNT", [], "count")],
-    filter_expr="@count > 10",  # Only departments with >10 employees
-)
-```
-
-### Sorting and Pagination
-
-```python
-df = redis.aggregate_hashes(
-    "redis://localhost:6379",
-    index="users_idx",
-    query="*",
-    group_by=["@department"],
-    reduce=[("AVG", ["@salary"], "avg_salary")],
-    sort_by=[("@avg_salary", False)],  # Descending
-    limit=10,
-    offset=0,
-)
-```
-
-## Example: Analytics Dashboard
-
-```python
-import polars as pl
-import polars_redis as redis
+import polars_redis as pr
 from polars_redis import col
 
 url = "redis://localhost:6379"
 
-# Filter active users in engineering
-engineers = redis.search_hashes(
+# Find active employees over 30
+df = pr.search_hashes(
     url,
-    index="users_idx",
-    query=(col("department") == "engineering") & (col("status") == "active"),
-    schema={"name": pl.Utf8, "age": pl.Int64, "salary": pl.Float64},
+    index="employees_idx",
+    query=(col("age") > 30) & (col("status") == "active"),
+    schema={"name": pl.Utf8, "age": pl.Int64, "department": pl.Utf8},
 ).collect()
 
+print(df)
+# shape: (4, 3)
+# +-------+-----+-------------+
+# | name  | age | department  |
+# | ---   | --- | ---         |
+# | str   | i64 | str         |
+# +=======+=====+=============+
+# | Alice | 32  | engineering |
+# | Carol | 45  | product     |
+# | Frank | 52  | engineering |
+# | Grace | 38  | marketing   |
+# +-------+-----+-------------+
+```
+
+## Basic Aggregation
+
+`aggregate_hashes()` uses FT.AGGREGATE for server-side grouping:
+
+```python
 # Salary statistics by department
-salary_stats = redis.aggregate_hashes(
+df = pr.aggregate_hashes(
     url,
-    index="users_idx",
+    index="employees_idx",
     query="@status:{active}",
     group_by=["@department"],
     reduce=[
         ("COUNT", [], "headcount"),
         ("AVG", ["@salary"], "avg_salary"),
-        ("MIN", ["@salary"], "min_salary"),
-        ("MAX", ["@salary"], "max_salary"),
+        ("SUM", ["@salary"], "total_payroll"),
     ],
-    sort_by=[("@avg_salary", False)],
+    sort_by=[("@avg_salary", False)],  # Descending
 )
 
-print(salary_stats)
+print(df)
+# shape: (3, 4)
+# +-------------+-----------+------------+--------------+
+# | department  | headcount | avg_salary | total_payroll|
+# | ---         | ---       | ---        | ---          |
+# | str         | i64       | f64        | f64          |
+# +=============+===========+============+==============+
+# | engineering | 3         | 121666.67  | 365000.0     |
+# | product     | 1         | 140000.0   | 140000.0     |
+# | marketing   | 2         | 90000.0    | 180000.0     |
+# +-------------+-----------+------------+--------------+
 ```
 
-## Advanced Search Options
+Only the aggregated results transfer - not the raw documents.
 
-For fine-grained control over search behavior, use `SearchOptions`:
+## Smart Scan: Automatic Optimization
 
-```python
-from polars_redis.options import SearchOptions, HighlightOptions, SummarizeOptions
-
-# Create options with advanced settings
-opts = SearchOptions(
-    index="articles_idx",
-    query="python programming",
-    verbatim=True,           # Disable stemming
-    language="english",       # Stemming language
-    scorer="BM25",           # Scoring algorithm
-    dialect=4,               # RediSearch dialect
-).with_highlight(
-    open_tag="<mark>",
-    close_tag="</mark>",
-).with_summarize(
-    len=50,
-    separator="...",
-)
-
-df = redis.search_hashes(
-    "redis://localhost:6379",
-    options=opts,
-    schema={"title": pl.Utf8, "body": pl.Utf8},
-).collect()
-```
-
-### Query Modifiers
-
-| Option | Description |
-|--------|-------------|
-| `verbatim` | Disable stemming for exact term matching |
-| `no_stopwords` | Include stop words in the query |
-| `language` | Language for stemming (e.g., "english", "spanish") |
-| `scorer` | Scoring function: "BM25", "TFIDF", "DISMAX" |
-| `expander` | Query expander: "SYNONYM" |
-| `slop` | Default slop for phrase queries |
-| `in_order` | Require phrase terms in order |
-| `dialect` | RediSearch dialect version (1-4) |
-
-### Filtering Options
-
-| Option | Description |
-|--------|-------------|
-| `in_keys` | Limit search to specific document keys |
-| `in_fields` | Limit search to specific fields |
-| `timeout_ms` | Query timeout in milliseconds |
-
-### Result Enrichment
-
-#### Highlighting
-
-Wrap matching terms in custom tags:
-
-```python
-opts = SearchOptions(
-    index="articles_idx",
-    query="python",
-).with_highlight(
-    fields=["title", "body"],
-    open_tag="<em>",
-    close_tag="</em>",
-)
-```
-
-#### Summarization
-
-Generate text snippets with matched terms:
-
-```python
-opts = SearchOptions(
-    index="articles_idx",
-    query="machine learning",
-).with_summarize(
-    fields=["body"],
-    frags=3,      # Number of fragments
-    len=30,       # Fragment length in words
-    separator="...",
-)
-```
-
-### Relevance Scores
-
-Include relevance scores in results:
-
-```python
-opts = SearchOptions(
-    index="articles_idx",
-    query="python",
-).with_score(True, "_relevance")
-
-df = redis.search_hashes(
-    "redis://localhost:6379",
-    options=opts,
-    schema={"title": pl.Utf8},
-).collect()
-
-# Results include _relevance column with scores
-```
-
-## Enhanced Client-Side Operations
-
-Some operations can't be pushed to RediSearch but execute efficiently in Polars after fetching results. These enable powerful filtering beyond RediSearch's capabilities.
-
-### Regex Matching
-
-```python
-# Match email patterns (runs in Polars)
-query = col("email").matches_regex(r".*@gmail\.com$")
-
-# Combine with server-side filter
-query = (col("status") == "active") & col("email").matches_regex(r".*@company\.com")
-```
-
-### Case-Insensitive Matching
-
-```python
-# Case-insensitive contains
-query = col("name").icontains("john")
-
-# Case-insensitive equality
-query = col("department").iequals("ENGINEERING")
-```
-
-### Multiple Substring Matching
-
-```python
-# Match any of multiple substrings
-query = col("description").contains_any(["python", "rust", "go"])
-```
-
-### String Similarity
-
-Match strings using Levenshtein distance:
-
-```python
-# Find names similar to "john" (80% similarity threshold)
-query = col("name").similar_to("john", threshold=0.8)
-```
-
-### Date/Time Operations
-
-Parse and filter by date fields:
-
-```python
-# Date comparisons
-query = col("created_at").as_date() > "2024-01-01"
-query = col("updated_at").as_datetime() >= "2024-06-15T12:00:00"
-
-# Date part extraction
-query = col("birth_date").as_date().year() == 1990
-query = col("created_at").as_date().month().is_in([1, 2, 3])  # Q1
-query = col("event_time").as_datetime().hour() >= 9
-
-# Available date parts: year(), month(), day(), weekday(), hour(), minute()
-```
-
-### Array/JSON Operations
-
-For JSON documents:
-
-```python
-# Check if array contains value
-query = col("tags").array_contains("python")
-
-# Filter by array length
-query = col("items").array_len() > 5
-
-# Extract nested JSON value
-query = col("metadata").json_path("$.user.role") == "admin"
-```
-
-## Hybrid Query Execution
-
-When queries combine server-side and client-side operations, polars-redis automatically splits execution:
-
-```python
-# This query has both server-pushable and client-side parts
-query = (col("age") > 30) & col("email").matches_regex(r".*@gmail\.com")
-
-# Check what runs where
-print(query.is_client_side)  # True
-
-# Extract server portion
-server_filter = query.get_server_filter()
-print(server_filter.to_redis())  # @age:[(30 +inf]
-
-# Extract client portion
-client_filter = query.get_client_filter()
-print(client_filter._op)  # "regex"
-
-# View execution plan
-print(query.explain())
-# RediSearch: @age:[(30 +inf]
-# Polars filter: pl.col("email").str.contains(r".*@gmail\.com")
-```
-
-### Execution Strategy
-
-1. **Pure server-side**: All predicates pushed to RediSearch
-2. **Pure client-side**: Fetch all, filter in Polars
-3. **Hybrid**: Push what we can, filter rest in Polars
-
-The query builder automatically optimizes for minimum data transfer.
-
-## Smart Scan: Automatic Index Detection
-
-The `smart_scan()` function provides a higher-level API that automatically detects whether a RediSearch index exists for your key pattern and optimizes query execution accordingly. This enables "RediSearch without learning RediSearch" - you get the performance benefits of FT.SEARCH when indexes are available, with automatic fallback to SCAN when they're not.
-
-### Basic Usage
+Don't want to think about indexes? Use `smart_scan()`:
 
 ```python
 from polars_redis import smart_scan
 
 # Auto-detect index and use FT.SEARCH if available
 df = smart_scan(
-    "redis://localhost:6379",
-    "user:*",
-    schema={"name": pl.Utf8, "age": pl.Int64, "status": pl.Utf8},
+    url,
+    "employee:*",
+    schema={"name": pl.Utf8, "age": pl.Int64},
 ).filter(pl.col("age") > 30).collect()
 ```
 
-If an index exists with prefix "user:", `smart_scan` uses FT.SEARCH automatically. Otherwise, it falls back to SCAN - same API, optimal execution.
+If an index exists for the pattern, `smart_scan` uses FT.SEARCH automatically. Otherwise, it falls back to SCAN - same API, optimal execution.
 
-### Parameters
+## Debugging Queries
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `url` | str | required | Redis connection URL |
-| `pattern` | str | `"*"` | Key pattern to match |
-| `schema` | dict | required | Field names to Polars dtypes |
-| `index` | str or Index | `None` | Force use of specific index |
-| `include_key` | bool | `True` | Include Redis key as column |
-| `key_column_name` | str | `"_key"` | Name of key column |
-| `include_ttl` | bool | `False` | Include TTL as column |
-| `ttl_column_name` | str | `"_ttl"` | Name of TTL column |
-| `batch_size` | int | `1000` | Documents per batch |
-| `auto_detect_index` | bool | `True` | Auto-detect matching indexes |
+See what RediSearch query gets generated:
 
-### Execution Strategies
+```python
+query = (col("department") == "engineering") & (col("salary") > 100000)
+print(query.to_redis())
+# @department:{engineering} @salary:[(100000 +inf]
+```
 
-`smart_scan` chooses from three strategies:
-
-| Strategy | When Used | Description |
-|----------|-----------|-------------|
-| **SEARCH** | Index found for pattern | Uses FT.SEARCH for server-side filtering |
-| **SCAN** | No matching index | Falls back to Redis SCAN |
-| **HYBRID** | Partial predicate pushdown | FT.SEARCH + client-side filtering |
-
-### Query Explanation
-
-Use `explain_scan()` to see exactly how a query will execute before running it:
+See how a query will execute:
 
 ```python
 from polars_redis import explain_scan
 
-plan = explain_scan(
-    "redis://localhost:6379",
-    "user:*",
-    schema={"name": pl.Utf8, "age": pl.Int64},
-)
-
+plan = explain_scan(url, "employee:*", schema={"name": pl.Utf8})
 print(plan.explain())
 # Strategy: SEARCH
-# Index: users_idx
-#   Prefixes: user:
+# Index: employees_idx
+#   Prefixes: employee:
 #   Type: HASH
-# Server Query: *
 ```
 
-The `QueryPlan` object provides:
+## Next Steps
 
-- `strategy`: ExecutionStrategy enum (SEARCH, SCAN, or HYBRID)
-- `index`: DetectedIndex with name, prefixes, type, and fields
-- `server_query`: RediSearch query that will run server-side
-- `client_filters`: Filters that will run in Polars
-- `warnings`: Any optimization warnings
-
-### Index Discovery
-
-Explore available indexes:
-
-```python
-from polars_redis import list_indexes, find_index_for_pattern
-
-# List all RediSearch indexes
-indexes = list_indexes("redis://localhost:6379")
-for idx in indexes:
-    print(f"{idx.name}: prefixes={idx.prefixes}, fields={idx.fields}")
-
-# Find index for specific pattern
-idx = find_index_for_pattern("redis://localhost:6379", "user:*")
-if idx:
-    print(f"Found index: {idx.name}")
-else:
-    print("No index covers this pattern")
-```
-
-### Explicit Index Control
-
-Override auto-detection when needed:
-
-```python
-# Use a specific index by name
-df = smart_scan(
-    url,
-    "user:*",
-    schema={"name": pl.Utf8},
-    index="users_idx",
-    auto_detect_index=False,
-)
-
-# Use an Index object (auto-creates if needed)
-from polars_redis import Index, TextField, NumericField
-
-idx = Index(
-    name="users_idx",
-    prefix="user:",
-    schema=[TextField("name"), NumericField("age")],
-)
-
-df = smart_scan(
-    url,
-    "user:*",
-    schema={"name": pl.Utf8, "age": pl.Int64},
-    index=idx,
-).collect()
-```
-
-### Graceful Degradation
-
-When RediSearch is unavailable (no module loaded), `smart_scan` falls back to SCAN without errors:
-
-```python
-# Works whether RediSearch is available or not
-df = smart_scan(
-    url,
-    "user:*",
-    schema={"name": pl.Utf8, "age": pl.Int64},
-).collect()
-```
-
-This makes `smart_scan` the recommended default for new code - you get automatic optimization when indexes exist, with zero changes needed when they don't.
+- **[Query Builder](redisearch-queries.md)** - Deep dive into all query operations
+- **[Aggregation](redisearch-aggregation.md)** - FT.AGGREGATE details and examples
+- **[Index Management](index-management.md)** - Creating and managing indexes
+- **[Advanced Queries](../examples/advanced-queries.md)** - Real-world query patterns
 
 ## Performance Comparison
 
@@ -904,5 +253,3 @@ This makes `smart_scan` the recommended default for new code - you get automatic
 | `search_hashes()` | Only matching docs | Indexed data, selective queries |
 | `smart_scan()` | Optimized automatically | Best default - auto-selects strategy |
 | `aggregate_hashes()` | Only aggregated results | Analytics, reporting |
-
-For large datasets with selective queries, RediSearch can reduce data transfer by 90%+ compared to scanning. With `smart_scan`, you get this optimization automatically when indexes are available.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,9 +72,12 @@ nav:
       - Pub/Sub: guide/pubsub.md
       - Redis Streams: guide/streams.md
   - RediSearch:
-      - Queries & Aggregation: guide/redisearch.md
+      - Overview: guide/redisearch.md
+      - Query Builder: guide/redisearch-queries.md
+      - Aggregation: guide/redisearch-aggregation.md
       - Index Management: guide/index-management.md
-      - Advanced Queries: examples/advanced-queries.md
+      - Advanced Options: guide/redisearch-advanced.md
+      - Query Examples: examples/advanced-queries.md
   - Client Operations:
       - Overview: guide/client-operations.md
   - Operations:


### PR DESCRIPTION
## Summary

Split the monolithic `redisearch.md` (800+ lines) into focused, navigable pages.

## New Structure

| Page | Content |
|------|---------|
| **Overview** (`redisearch.md`) | Why RediSearch, when to use/not use, setup test data, basic search/aggregation examples |
| **Query Builder** (`redisearch-queries.md`) | All query operations: comparisons, text search, geo, vector, tags, client-side filters |
| **Aggregation** (`redisearch-aggregation.md`) | FT.AGGREGATE: GROUP BY, reduce functions, APPLY, filtering, sorting |
| **Advanced Options** (`redisearch-advanced.md`) | SearchOptions, highlighting, summarization, smart_scan, parameter references |

## Changes Address Feedback

1. **Split for navigation** - People scanning for 'how do I do a geo query' don't wade through vector search first
2. **Added 'When NOT to use RediSearch'** - Guidance for small datasets, one-off queries
3. **Added setup test data snippet** - Users can follow along with examples
4. **Renamed 'Enhanced Client-Side Operations'** to 'Client-Side Filters' with explicit explanation that these fetch data first
5. **Moved SearchOptions to advanced** - Clearly separated from main flow

## Nav Structure

```
RediSearch:
  - Overview
  - Query Builder
  - Aggregation
  - Index Management
  - Advanced Options
  - Query Examples
```