### PR TITLE
refactor: convert integration tests to use docker-wrapper

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -849,7 +849,7 @@ impl Index {
     pub fn create_if_not_exists_with_conn(&self, conn: &mut Connection) -> Result<()> {
         match self.create_with_conn(conn) {
             Ok(()) => Ok(()),
-            Err(Error::Connection(e)) if e.to_string().contains("Index already exists") => Ok(()),
+            Err(Error::Connection(e)) if e.to_string().contains("already exists") => Ok(()),
             Err(e) => Err(e),
         }
     }
@@ -877,7 +877,12 @@ impl Index {
         }
         match cmd.query::<()>(conn) {
             Ok(()) => Ok(()),
-            Err(e) if e.to_string().contains("Unknown index name") => Ok(()),
+            Err(e)
+                if e.to_string().contains("Unknown index name")
+                    || e.to_string().contains("no such index") =>
+            {
+                Ok(())
+            },
             Err(e) => Err(Error::Connection(e)),
         }
     }
@@ -896,7 +901,12 @@ impl Index {
             .query::<Vec<redis::Value>>(conn)
         {
             Ok(_) => Ok(true),
-            Err(e) if e.to_string().contains("Unknown index name") => Ok(false),
+            Err(e)
+                if e.to_string().contains("Unknown index name")
+                    || e.to_string().contains("no such index") =>
+            {
+                Ok(false)
+            },
             Err(e) => Err(Error::Connection(e)),
         }
     }

--- a/tests/integration_pipeline.rs
+++ b/tests/integration_pipeline.rs
@@ -4,72 +4,104 @@
 
 use polars_redis::client::pipeline::{CommandResult, Pipeline, Transaction};
 
+mod common;
+use common::{ensure_redis, get_redis_url};
+
 /// Test that pipeline creation works.
-#[test]
-#[ignore] // Requires Redis
-fn test_pipeline_basic_operations() {
-    let mut pipe = Pipeline::new("redis://localhost:6379").unwrap();
+#[tokio::test]
+async fn test_pipeline_basic_operations() {
+    let _ = ensure_redis().await;
+    let url = get_redis_url().to_string();
 
-    // Queue some operations
-    pipe.set("pipe_test:key1", "value1");
-    pipe.set("pipe_test:key2", "value2");
-    pipe.get("pipe_test:key1");
-    pipe.get("pipe_test:key2");
+    let result = tokio::task::spawn_blocking(move || {
+        let mut pipe = Pipeline::new(&url).unwrap();
 
-    assert_eq!(pipe.len(), 4);
+        // Queue some operations
+        pipe.set("pipe_test:key1", "value1");
+        pipe.set("pipe_test:key2", "value2");
+        pipe.get("pipe_test:key1");
+        pipe.get("pipe_test:key2");
 
-    let result = pipe.execute().unwrap();
+        assert_eq!(pipe.len(), 4);
+
+        let result = pipe.execute().unwrap();
+
+        // Cleanup
+        let mut cleanup = Pipeline::new(&url).unwrap();
+        cleanup.del(&["pipe_test:key1", "pipe_test:key2"]);
+        let _ = cleanup.execute();
+
+        result
+    })
+    .await
+    .expect("spawn_blocking failed");
 
     assert_eq!(result.results.len(), 4);
     assert!(result.all_succeeded());
 
     // First two are SET commands (return OK)
     assert!(result.get(0).unwrap().is_ok() || matches!(result.get(0), Some(CommandResult::Int(_))));
-
-    // Cleanup
-    let mut cleanup = Pipeline::new("redis://localhost:6379").unwrap();
-    cleanup.del(&["pipe_test:key1", "pipe_test:key2"]);
-    let _ = cleanup.execute();
 }
 
 /// Test pipeline with hash operations.
-#[test]
-#[ignore] // Requires Redis
-fn test_pipeline_hash_operations() {
-    let mut pipe = Pipeline::new("redis://localhost:6379").unwrap();
+#[tokio::test]
+async fn test_pipeline_hash_operations() {
+    let _ = ensure_redis().await;
+    let url = get_redis_url().to_string();
 
-    // Set up a hash
-    pipe.hmset(
-        "pipe_test:hash1",
-        &[("field1", "value1"), ("field2", "value2")],
-    );
-    pipe.hget("pipe_test:hash1", "field1");
-    pipe.hgetall("pipe_test:hash1");
-    pipe.hincrby("pipe_test:hash1", "counter", 10);
+    let result = tokio::task::spawn_blocking(move || {
+        let mut pipe = Pipeline::new(&url).unwrap();
 
-    let result = pipe.execute().unwrap();
+        // Set up a hash
+        pipe.hmset(
+            "pipe_test:hash1",
+            &[("field1", "value1"), ("field2", "value2")],
+        );
+        pipe.hget("pipe_test:hash1", "field1");
+        pipe.hgetall("pipe_test:hash1");
+        pipe.hincrby("pipe_test:hash1", "counter", 10);
+
+        let result = pipe.execute().unwrap();
+
+        // Cleanup
+        let mut cleanup = Pipeline::new(&url).unwrap();
+        cleanup.del(&["pipe_test:hash1"]);
+        let _ = cleanup.execute();
+
+        result
+    })
+    .await
+    .expect("spawn_blocking failed");
 
     assert_eq!(result.results.len(), 4);
     assert!(result.all_succeeded());
-
-    // Cleanup
-    let mut cleanup = Pipeline::new("redis://localhost:6379").unwrap();
-    cleanup.del(&["pipe_test:hash1"]);
-    let _ = cleanup.execute();
 }
 
 /// Test pipeline with list operations.
-#[test]
-#[ignore] // Requires Redis
-fn test_pipeline_list_operations() {
-    let mut pipe = Pipeline::new("redis://localhost:6379").unwrap();
+#[tokio::test]
+async fn test_pipeline_list_operations() {
+    let _ = ensure_redis().await;
+    let url = get_redis_url().to_string();
 
-    // Set up a list
-    pipe.rpush("pipe_test:list1", &["a", "b", "c"]);
-    pipe.llen("pipe_test:list1");
-    pipe.lrange("pipe_test:list1", 0, -1);
+    let result = tokio::task::spawn_blocking(move || {
+        let mut pipe = Pipeline::new(&url).unwrap();
 
-    let result = pipe.execute().unwrap();
+        // Set up a list
+        pipe.rpush("pipe_test:list1", &["a", "b", "c"]);
+        pipe.llen("pipe_test:list1");
+        pipe.lrange("pipe_test:list1", 0, -1);
+
+        let result = pipe.execute().unwrap();
+
+        // Cleanup
+        let mut cleanup = Pipeline::new(&url).unwrap();
+        cleanup.del(&["pipe_test:list1"]);
+        let _ = cleanup.execute();
+
+        result
+    })
+    .await
+    .expect("spawn_blocking failed");
 
     assert_eq!(result.results.len(), 3);
     assert!(result.all_succeeded());
@@ -78,26 +110,34 @@ fn test_pipeline_list_operations() {
     if let Some(CommandResult::Int(len)) = result.get(1) {
         assert_eq!(*len, 3);
     }
-
-    // Cleanup
-    let mut cleanup = Pipeline::new("redis://localhost:6379").unwrap();
-    cleanup.del(&["pipe_test:list1"]);
-    let _ = cleanup.execute();
 }
 
 /// Test pipeline with set operations.
-#[test]
-#[ignore] // Requires Redis
-fn test_pipeline_set_operations() {
-    let mut pipe = Pipeline::new("redis://localhost:6379").unwrap();
+#[tokio::test]
+async fn test_pipeline_set_operations() {
+    let _ = ensure_redis().await;
+    let url = get_redis_url().to_string();
 
-    // Set up a set
-    pipe.sadd("pipe_test:set1", &["member1", "member2", "member3"]);
-    pipe.scard("pipe_test:set1");
-    pipe.sismember("pipe_test:set1", "member1");
-    pipe.smembers("pipe_test:set1");
+    let result = tokio::task::spawn_blocking(move || {
+        let mut pipe = Pipeline::new(&url).unwrap();
 
-    let result = pipe.execute().unwrap();
+        // Set up a set
+        pipe.sadd("pipe_test:set1", &["member1", "member2", "member3"]);
+        pipe.scard("pipe_test:set1");
+        pipe.sismember("pipe_test:set1", "member1");
+        pipe.smembers("pipe_test:set1");
+
+        let result = pipe.execute().unwrap();
+
+        // Cleanup
+        let mut cleanup = Pipeline::new(&url).unwrap();
+        cleanup.del(&["pipe_test:set1"]);
+        let _ = cleanup.execute();
+
+        result
+    })
+    .await
+    .expect("spawn_blocking failed");
 
     assert_eq!(result.results.len(), 4);
     assert!(result.all_succeeded());
@@ -111,26 +151,34 @@ fn test_pipeline_set_operations() {
     if let Some(CommandResult::Int(is_member)) = result.get(2) {
         assert_eq!(*is_member, 1);
     }
-
-    // Cleanup
-    let mut cleanup = Pipeline::new("redis://localhost:6379").unwrap();
-    cleanup.del(&["pipe_test:set1"]);
-    let _ = cleanup.execute();
 }
 
 /// Test pipeline with sorted set operations.
-#[test]
-#[ignore] // Requires Redis
-fn test_pipeline_zset_operations() {
-    let mut pipe = Pipeline::new("redis://localhost:6379").unwrap();
+#[tokio::test]
+async fn test_pipeline_zset_operations() {
+    let _ = ensure_redis().await;
+    let url = get_redis_url().to_string();
 
-    // Set up a sorted set
-    pipe.zadd("pipe_test:zset1", &[(1.0, "a"), (2.0, "b"), (3.0, "c")]);
-    pipe.zcard("pipe_test:zset1");
-    pipe.zscore("pipe_test:zset1", "b");
-    pipe.zrange("pipe_test:zset1", 0, -1);
+    let result = tokio::task::spawn_blocking(move || {
+        let mut pipe = Pipeline::new(&url).unwrap();
 
-    let result = pipe.execute().unwrap();
+        // Set up a sorted set
+        pipe.zadd("pipe_test:zset1", &[(1.0, "a"), (2.0, "b"), (3.0, "c")]);
+        pipe.zcard("pipe_test:zset1");
+        pipe.zscore("pipe_test:zset1", "b");
+        pipe.zrange("pipe_test:zset1", 0, -1);
+
+        let result = pipe.execute().unwrap();
+
+        // Cleanup
+        let mut cleanup = Pipeline::new(&url).unwrap();
+        cleanup.del(&["pipe_test:zset1"]);
+        let _ = cleanup.execute();
+
+        result
+    })
+    .await
+    .expect("spawn_blocking failed");
 
     assert_eq!(result.results.len(), 4);
     assert!(result.all_succeeded());
@@ -139,141 +187,188 @@ fn test_pipeline_zset_operations() {
     if let Some(CommandResult::Int(card)) = result.get(1) {
         assert_eq!(*card, 3);
     }
-
-    // Cleanup
-    let mut cleanup = Pipeline::new("redis://localhost:6379").unwrap();
-    cleanup.del(&["pipe_test:zset1"]);
-    let _ = cleanup.execute();
 }
 
 /// Test transaction basic operations.
-#[test]
-#[ignore] // Requires Redis
-fn test_transaction_basic() {
-    let mut tx = Transaction::new("redis://localhost:6379").unwrap();
+#[tokio::test]
+async fn test_transaction_basic() {
+    let _ = ensure_redis().await;
+    let url = get_redis_url().to_string();
 
-    // Queue atomic operations
-    tx.set("tx_test:key1", "value1");
-    tx.set("tx_test:key2", "value2");
-    tx.incr("tx_test:counter");
-    tx.incr("tx_test:counter");
+    let result = tokio::task::spawn_blocking(move || {
+        let mut tx = Transaction::new(&url).unwrap();
 
-    assert_eq!(tx.len(), 4);
+        // Queue atomic operations
+        tx.set("tx_test:key1", "value1");
+        tx.set("tx_test:key2", "value2");
+        tx.incr("tx_test:counter");
+        tx.incr("tx_test:counter");
 
-    let result = tx.execute().unwrap();
+        assert_eq!(tx.len(), 4);
+
+        let result = tx.execute().unwrap();
+
+        // Cleanup
+        let mut cleanup = Pipeline::new(&url).unwrap();
+        cleanup.del(&["tx_test:key1", "tx_test:key2", "tx_test:counter"]);
+        let _ = cleanup.execute();
+
+        result
+    })
+    .await
+    .expect("spawn_blocking failed");
 
     assert_eq!(result.results.len(), 4);
     assert!(result.all_succeeded());
-
-    // Cleanup
-    let mut cleanup = Pipeline::new("redis://localhost:6379").unwrap();
-    cleanup.del(&["tx_test:key1", "tx_test:key2", "tx_test:counter"]);
-    let _ = cleanup.execute();
 }
 
 /// Test transaction with hash operations.
-#[test]
-#[ignore] // Requires Redis
-fn test_transaction_hash_operations() {
-    let mut tx = Transaction::new("redis://localhost:6379").unwrap();
+#[tokio::test]
+async fn test_transaction_hash_operations() {
+    let _ = ensure_redis().await;
+    let url = get_redis_url().to_string();
 
-    // Atomic hash operations
-    tx.hset("tx_test:hash1", "field1", "value1");
-    tx.hset("tx_test:hash1", "field2", "value2");
-    tx.hincrby("tx_test:hash1", "counter", 5);
+    let result = tokio::task::spawn_blocking(move || {
+        let mut tx = Transaction::new(&url).unwrap();
 
-    let result = tx.execute().unwrap();
+        // Atomic hash operations
+        tx.hset("tx_test:hash1", "field1", "value1");
+        tx.hset("tx_test:hash1", "field2", "value2");
+        tx.hincrby("tx_test:hash1", "counter", 5);
+
+        let result = tx.execute().unwrap();
+
+        // Cleanup
+        let mut cleanup = Pipeline::new(&url).unwrap();
+        cleanup.del(&["tx_test:hash1"]);
+        let _ = cleanup.execute();
+
+        result
+    })
+    .await
+    .expect("spawn_blocking failed");
 
     assert_eq!(result.results.len(), 3);
     assert!(result.all_succeeded());
-
-    // Cleanup
-    let mut cleanup = Pipeline::new("redis://localhost:6379").unwrap();
-    cleanup.del(&["tx_test:hash1"]);
-    let _ = cleanup.execute();
 }
 
 /// Test pipeline clear and reuse.
-#[test]
-fn test_pipeline_clear() {
-    let mut pipe = Pipeline::new("redis://localhost:6379").unwrap();
+#[tokio::test]
+async fn test_pipeline_clear() {
+    let _ = ensure_redis().await;
+    let url = get_redis_url().to_string();
 
-    pipe.set("key1", "value1");
-    pipe.set("key2", "value2");
-    assert_eq!(pipe.len(), 2);
+    tokio::task::spawn_blocking(move || {
+        let mut pipe = Pipeline::new(&url).unwrap();
 
-    pipe.clear();
-    assert!(pipe.is_empty());
-    assert_eq!(pipe.len(), 0);
+        pipe.set("key1", "value1");
+        pipe.set("key2", "value2");
+        assert_eq!(pipe.len(), 2);
+
+        pipe.clear();
+        assert!(pipe.is_empty());
+        assert_eq!(pipe.len(), 0);
+    })
+    .await
+    .expect("spawn_blocking failed");
 }
 
 /// Test transaction discard.
-#[test]
-fn test_transaction_discard() {
-    let mut tx = Transaction::new("redis://localhost:6379").unwrap();
+#[tokio::test]
+async fn test_transaction_discard() {
+    let _ = ensure_redis().await;
+    let url = get_redis_url().to_string();
 
-    tx.set("key1", "value1");
-    tx.set("key2", "value2");
-    assert_eq!(tx.len(), 2);
+    tokio::task::spawn_blocking(move || {
+        let mut tx = Transaction::new(&url).unwrap();
 
-    tx.discard();
-    assert!(tx.is_empty());
-    assert_eq!(tx.len(), 0);
+        tx.set("key1", "value1");
+        tx.set("key2", "value2");
+        assert_eq!(tx.len(), 2);
+
+        tx.discard();
+        assert!(tx.is_empty());
+        assert_eq!(tx.len(), 0);
+    })
+    .await
+    .expect("spawn_blocking failed");
 }
 
 /// Test raw command support.
-#[test]
-#[ignore] // Requires Redis
-fn test_pipeline_raw_command() {
-    let mut pipe = Pipeline::new("redis://localhost:6379").unwrap();
+#[tokio::test]
+async fn test_pipeline_raw_command() {
+    let _ = ensure_redis().await;
+    let url = get_redis_url().to_string();
 
-    pipe.raw("SET", &["raw_test:key", "raw_value"]);
-    pipe.raw("GET", &["raw_test:key"]);
+    let result = tokio::task::spawn_blocking(move || {
+        let mut pipe = Pipeline::new(&url).unwrap();
 
-    let result = pipe.execute().unwrap();
+        pipe.raw("SET", &["raw_test:key", "raw_value"]);
+        pipe.raw("GET", &["raw_test:key"]);
+
+        let result = pipe.execute().unwrap();
+
+        // Cleanup
+        let mut cleanup = Pipeline::new(&url).unwrap();
+        cleanup.del(&["raw_test:key"]);
+        let _ = cleanup.execute();
+
+        result
+    })
+    .await
+    .expect("spawn_blocking failed");
 
     assert_eq!(result.results.len(), 2);
     assert!(result.all_succeeded());
-
-    // Cleanup
-    let mut cleanup = Pipeline::new("redis://localhost:6379").unwrap();
-    cleanup.del(&["raw_test:key"]);
-    let _ = cleanup.execute();
 }
 
 /// Test empty pipeline execution.
-#[test]
-#[ignore] // Requires Redis
-fn test_empty_pipeline() {
-    let mut pipe = Pipeline::new("redis://localhost:6379").unwrap();
-    assert!(pipe.is_empty());
+#[tokio::test]
+async fn test_empty_pipeline() {
+    let _ = ensure_redis().await;
+    let url = get_redis_url().to_string();
 
-    let result = pipe.execute().unwrap();
+    let result = tokio::task::spawn_blocking(move || {
+        let mut pipe = Pipeline::new(&url).unwrap();
+        assert!(pipe.is_empty());
+
+        pipe.execute().unwrap()
+    })
+    .await
+    .expect("spawn_blocking failed");
 
     assert_eq!(result.results.len(), 0);
     assert!(result.all_succeeded());
 }
 
 /// Test key management commands.
-#[test]
-#[ignore] // Requires Redis
-fn test_pipeline_key_management() {
-    let mut pipe = Pipeline::new("redis://localhost:6379").unwrap();
+#[tokio::test]
+async fn test_pipeline_key_management() {
+    let _ = ensure_redis().await;
+    let url = get_redis_url().to_string();
 
-    // Set up keys
-    pipe.set("key_mgmt:key1", "value1");
-    pipe.set("key_mgmt:key2", "value2");
-    pipe.exists(&["key_mgmt:key1", "key_mgmt:key2"]);
-    pipe.ttl("key_mgmt:key1");
-    pipe.expire("key_mgmt:key1", 3600);
-    pipe.key_type("key_mgmt:key1");
+    let result = tokio::task::spawn_blocking(move || {
+        let mut pipe = Pipeline::new(&url).unwrap();
 
-    let result = pipe.execute().unwrap();
+        // Set up keys
+        pipe.set("key_mgmt:key1", "value1");
+        pipe.set("key_mgmt:key2", "value2");
+        pipe.exists(&["key_mgmt:key1", "key_mgmt:key2"]);
+        pipe.ttl("key_mgmt:key1");
+        pipe.expire("key_mgmt:key1", 3600);
+        pipe.key_type("key_mgmt:key1");
+
+        let result = pipe.execute().unwrap();
+
+        // Cleanup
+        let mut cleanup = Pipeline::new(&url).unwrap();
+        cleanup.del(&["key_mgmt:key1", "key_mgmt:key2"]);
+        let _ = cleanup.execute();
+
+        result
+    })
+    .await
+    .expect("spawn_blocking failed");
 
     assert!(result.all_succeeded());
-
-    // Cleanup
-    let mut cleanup = Pipeline::new("redis://localhost:6379").unwrap();
-    cleanup.del(&["key_mgmt:key1", "key_mgmt:key2"]);
-    let _ = cleanup.execute();
 }


### PR DESCRIPTION
## Summary

Convert all integration tests from the old `#[test] #[ignore]` pattern to `#[tokio::test]` with automatic Redis container management via docker-wrapper.

## Changes

### Test Infrastructure
- All integration tests now use `ensure_redis().await` which auto-detects running Redis or starts a container
- Wrapped sync Redis operations in `spawn_blocking` to avoid runtime nesting errors
- Improved `wait_for_index` to properly check `percent_indexed` status before running search tests

### Library Fixes
- Fixed `Index::exists` and `Index::drop` to handle both 'Unknown index name' and 'no such index' error messages
- Fixed `Index::create_if_not_exists` to handle 'already exists' error variants from different Redis versions

### Test Fixes
- Fixed `test_geo_large_set` to use valid latitude range for Redis GEOADD (-85 to 85, not -90 to 90)

## Testing
- `cargo test --lib --all-features` - 325 tests pass
- `cargo clippy --all-targets --all-features -- -D warnings` - passes
- Integration tests pass (except 2 pre-existing search query issues unrelated to this PR)

## Notes
- The CI workflow may need updates to run integration tests without `--ignored` flag since tests are no longer ignored
- Tests can still use `REDIS_URL` env var for CI with GitHub Actions service containers