### PR TITLE
refactor: standardize async iterator naming conventions

### DIFF
--- a/docs/guide/pubsub.md
+++ b/docs/guide/pubsub.md
@@ -188,7 +188,7 @@ For continuous streaming, use iterators that yield batches of messages:
 
 ```python
 # Process batches of up to 100 messages or every second
-for batch_df in redis.iter_batches(
+for batch_df in redis.iter_pubsub(
     "redis://localhost",
     channels=["events"],
     batch_size=100,
@@ -209,7 +209,7 @@ for batch_df in redis.iter_batches(
 import asyncio
 
 async def process_events():
-    async for batch_df in redis.subscribe_batches(
+    async for batch_df in redis.iter_pubsub_async(
         "redis://localhost",
         channels=["events"],
         batch_size=100,
@@ -301,7 +301,7 @@ Collect messages into a DataFrame.
 | `include_channel` | `bool` | `False` | Include channel column |
 | `include_timestamp` | `bool` | `False` | Include timestamp column |
 
-### `iter_batches()`
+### `iter_pubsub()`
 
 Synchronous iterator yielding DataFrame batches.
 
@@ -311,11 +311,11 @@ Synchronous iterator yielding DataFrame batches.
 | `batch_timeout_ms` | `int` | `1000` | Timeout to yield partial batch |
 | *(plus all `collect_pubsub` params)* | | | |
 
-### `subscribe_batches()`
+### `iter_pubsub_async()`
 
 Async iterator yielding DataFrame batches.
 
-Same parameters as `iter_batches()`.
+Same parameters as `iter_pubsub()`.
 
 ## See Also
 

--- a/docs/guide/streams.md
+++ b/docs/guide/streams.md
@@ -17,7 +17,7 @@ Redis Streams are append-only log data structures ideal for:
 - Single stream consumption with `read_stream()` and `scan_stream()`
 - Consumer group support for distributed processing
 - Blocking reads for real-time tailing
-- Batch iteration with `iter_stream()` and `stream_batches()`
+- Batch iteration with `iter_stream()` and `iter_stream_async()`
 - Manual or automatic message acknowledgment
 
 ## Differences from `scan_streams`/`read_streams`
@@ -227,7 +227,7 @@ for batch_df in redis.iter_stream(
 import asyncio
 
 async def process_stream():
-    async for batch_df in redis.stream_batches(
+    async for batch_df in redis.iter_stream_async(
         "redis://localhost",
         stream="events",
         batch_size=100,
@@ -337,7 +337,7 @@ Synchronous iterator yielding DataFrame batches.
 | `block_ms` | `int` | `1000` | Block timeout per batch |
 | *(plus all `read_stream` params)* | | | |
 
-### `stream_batches()`
+### `iter_stream_async()`
 
 Async iterator yielding DataFrame batches.
 

--- a/python/polars_redis/__init__.py
+++ b/python/polars_redis/__init__.py
@@ -105,8 +105,8 @@ from polars_redis._pipeline import (
 )
 from polars_redis._pubsub import (
     collect_pubsub,
-    iter_batches,
-    subscribe_batches,
+    iter_pubsub,
+    iter_pubsub_async,
 )
 from polars_redis._read import (
     read_hashes,
@@ -146,9 +146,9 @@ from polars_redis._smart import (
 from polars_redis._streams import (
     ack_entries,
     iter_stream,
+    iter_stream_async,
     read_stream,
     scan_stream,
-    stream_batches,
 )
 from polars_redis._write import (
     WriteResult,
@@ -285,13 +285,13 @@ __all__ = [
     "RenameResult",
     # Pub/Sub streaming
     "collect_pubsub",
-    "subscribe_batches",
-    "iter_batches",
+    "iter_pubsub",
+    "iter_pubsub_async",
     # Stream consumption (single stream with consumer groups)
     "read_stream",
     "scan_stream",
     "iter_stream",
-    "stream_batches",
+    "iter_stream_async",
     "ack_entries",
     # Environment defaults
     "get_default_batch_size",

--- a/python/polars_redis/_pubsub.py
+++ b/python/polars_redis/_pubsub.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import threading
 import time
 from collections.abc import AsyncIterator, Iterator
 from typing import Any, Callable, Literal
@@ -193,7 +192,7 @@ def collect_pubsub(
     return df
 
 
-async def subscribe_batches(
+async def iter_pubsub_async(
     url: str,
     channels: list[str],
     *,
@@ -209,7 +208,7 @@ async def subscribe_batches(
     message_column: str = "message",
     timestamp_column: str = "_received_at",
 ) -> AsyncIterator[pl.DataFrame]:
-    """Async iterator that yields batches of messages as DataFrames.
+    """Async iterator that yields batches of Pub/Sub messages as DataFrames.
 
     Subscribes to the specified channels and yields DataFrames containing
     batches of messages. Each batch contains up to `batch_size` messages
@@ -238,7 +237,7 @@ async def subscribe_batches(
         >>> import polars_redis as redis
         >>>
         >>> async def process_events():
-        ...     async for batch_df in redis.subscribe_batches(
+        ...     async for batch_df in redis.iter_pubsub_async(
         ...         "redis://localhost",
         ...         channels=["events"],
         ...         batch_size=100,
@@ -336,7 +335,7 @@ async def subscribe_batches(
         await client.close()
 
 
-def iter_batches(
+def iter_pubsub(
     url: str,
     channels: list[str],
     *,
@@ -352,10 +351,10 @@ def iter_batches(
     message_column: str = "message",
     timestamp_column: str = "_received_at",
 ) -> Iterator[pl.DataFrame]:
-    """Synchronous iterator that yields batches of messages as DataFrames.
+    """Synchronous iterator that yields batches of Pub/Sub messages as DataFrames.
 
-    This is a synchronous wrapper around subscribe_batches for use in
-    non-async contexts.
+    Subscribes to the specified channels and yields DataFrames containing
+    batches of messages for real-time processing.
 
     Args:
         url: Redis connection URL.
@@ -378,7 +377,7 @@ def iter_batches(
     Example:
         >>> import polars_redis as redis
         >>>
-        >>> for batch_df in redis.iter_batches(
+        >>> for batch_df in redis.iter_pubsub(
         ...     "redis://localhost",
         ...     channels=["events"],
         ...     batch_size=100,

--- a/python/polars_redis/_streams.py
+++ b/python/polars_redis/_streams.py
@@ -10,9 +10,8 @@ with consumer group support and real-time tailing.
 
 from __future__ import annotations
 
-import time
 from collections.abc import AsyncIterator, Iterator
-from typing import Any, Literal
+from typing import Any
 
 import polars as pl
 
@@ -299,7 +298,7 @@ def iter_stream(
         client.close()
 
 
-async def stream_batches(
+async def iter_stream_async(
     url: str,
     stream: str,
     *,
@@ -348,7 +347,7 @@ async def stream_batches(
         >>> import polars_redis as redis
         >>>
         >>> async def process_events():
-        ...     async for batch_df in redis.stream_batches(
+        ...     async for batch_df in redis.iter_stream_async(
         ...         "redis://localhost",
         ...         stream="events",
         ...         batch_size=100,

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -370,10 +370,10 @@ class TestCollectPubsub:
         assert "ts" in df.columns
 
 
-class TestIterBatches:
-    """Tests for iter_batches synchronous iterator."""
+class TestIterPubsub:
+    """Tests for iter_pubsub synchronous iterator."""
 
-    def test_iter_batches_by_size(self, redis_url: str, redis_available: bool) -> None:
+    def test_iter_pubsub_by_size(self, redis_url: str, redis_available: bool) -> None:
         """Test yielding batches by size."""
         if not redis_available:
             pytest.skip("Redis not available")
@@ -397,7 +397,7 @@ class TestIterBatches:
         thread.start()
 
         batches = []
-        for batch in pr.iter_batches(
+        for batch in pr.iter_pubsub(
             redis_url,
             channels=[channel],
             batch_size=5,
@@ -415,7 +415,7 @@ class TestIterBatches:
         # First batch should have up to 5 messages
         assert len(batches[0]) <= 5
 
-    def test_iter_batches_by_timeout(self, redis_url: str, redis_available: bool) -> None:
+    def test_iter_pubsub_by_timeout(self, redis_url: str, redis_available: bool) -> None:
         """Test yielding batches by timeout."""
         if not redis_available:
             pytest.skip("Redis not available")
@@ -437,7 +437,7 @@ class TestIterBatches:
         thread.start()
 
         batches = []
-        for batch in pr.iter_batches(
+        for batch in pr.iter_pubsub(
             redis_url,
             channels=[channel],
             batch_size=100,  # Large batch size
@@ -456,11 +456,11 @@ class TestIterBatches:
             assert len(batch) < 100
 
 
-class TestSubscribeBatches:
-    """Tests for subscribe_batches async iterator."""
+class TestIterPubsubAsync:
+    """Tests for iter_pubsub_async async iterator."""
 
     @pytest.mark.asyncio
-    async def test_subscribe_batches_basic(self, redis_url: str, redis_available: bool) -> None:
+    async def test_iter_pubsub_async_basic(self, redis_url: str, redis_available: bool) -> None:
         """Test basic async batch iteration."""
         if not redis_available:
             pytest.skip("Redis not available")
@@ -480,7 +480,7 @@ class TestSubscribeBatches:
         publish_task = asyncio.create_task(publish_messages())
 
         batches = []
-        async for batch in pr.subscribe_batches(
+        async for batch in pr.iter_pubsub_async(
             redis_url,
             channels=[channel],
             batch_size=5,
@@ -496,7 +496,7 @@ class TestSubscribeBatches:
         assert len(batches) >= 1
 
     @pytest.mark.asyncio
-    async def test_subscribe_batches_json(self, redis_url: str, redis_available: bool) -> None:
+    async def test_iter_pubsub_async_json(self, redis_url: str, redis_available: bool) -> None:
         """Test async iteration with JSON messages."""
         if not redis_available:
             pytest.skip("Redis not available")
@@ -517,7 +517,7 @@ class TestSubscribeBatches:
         publish_task = asyncio.create_task(publish_messages())
 
         batches = []
-        async for batch in pr.subscribe_batches(
+        async for batch in pr.iter_pubsub_async(
             redis_url,
             channels=[channel],
             batch_size=5,
@@ -565,11 +565,11 @@ class TestPubsubUnit:
 
     def test_imports(self) -> None:
         """Test that pubsub functions are importable."""
-        from polars_redis import collect_pubsub, iter_batches, subscribe_batches
+        from polars_redis import collect_pubsub, iter_pubsub, iter_pubsub_async
 
         assert callable(collect_pubsub)
-        assert callable(iter_batches)
-        assert callable(subscribe_batches)
+        assert callable(iter_pubsub)
+        assert callable(iter_pubsub_async)
 
     def test_collect_pubsub_signature(self) -> None:
         """Test function signature includes expected parameters."""

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import asyncio
 import time
 import uuid
-from typing import Any
 
 import polars as pl
 import pytest
@@ -479,11 +478,11 @@ class TestIterStream:
             client.close()
 
 
-class TestStreamBatches:
-    """Tests for stream_batches async iterator."""
+class TestIterStreamAsync:
+    """Tests for iter_stream_async async iterator."""
 
     @pytest.mark.asyncio
-    async def test_stream_batches_basic(self, redis_url: str, redis_available: bool) -> None:
+    async def test_iter_stream_async_basic(self, redis_url: str, redis_available: bool) -> None:
         """Test basic async batch iteration."""
         if not redis_available:
             pytest.skip("Redis not available")
@@ -504,7 +503,7 @@ class TestStreamBatches:
 
         try:
             batches = []
-            async for batch in pr.stream_batches(
+            async for batch in pr.iter_stream_async(
                 redis_url,
                 stream=stream,
                 batch_size=5,
@@ -531,15 +530,15 @@ class TestStreamsUnit:
         from polars_redis import (
             ack_entries,
             iter_stream,
+            iter_stream_async,
             read_stream,
             scan_stream,
-            stream_batches,
         )
 
         assert callable(read_stream)
         assert callable(scan_stream)
         assert callable(iter_stream)
-        assert callable(stream_batches)
+        assert callable(iter_stream_async)
         assert callable(ack_entries)
 
     def test_read_stream_signature(self) -> None:


### PR DESCRIPTION
## Summary

Standardizes the naming conventions for async iterator functions across the API for consistency and clarity.

## Changes

| Old Name | New Name | Module |
|----------|----------|--------|
| `stream_batches` | `iter_stream_async` | `_streams.py` |
| `subscribe_batches` | `iter_pubsub_async` | `_pubsub.py` |
| `iter_batches` | `iter_pubsub` | `_pubsub.py` |

## Naming Pattern

This establishes a clear, consistent naming pattern:
- **Sync iterators**: `iter_stream`, `iter_pubsub`
- **Async iterators**: `iter_stream_async`, `iter_pubsub_async`

The `_async` suffix was chosen over alternatives like `aiter_` prefix because it's more explicit and readable.

## Updated Files

- `python/polars_redis/_streams.py` - Renamed function
- `python/polars_redis/_pubsub.py` - Renamed functions
- `python/polars_redis/__init__.py` - Updated imports and exports
- `docs/guide/streams.md` - Updated documentation
- `docs/guide/pubsub.md` - Updated documentation
- `tests/test_streams.py` - Updated tests
- `tests/test_pubsub.py` - Updated tests

## Testing

- All 33 Python tests for streams and pubsub pass
- All 325 Rust tests pass
- Clippy passes with no warnings

Closes #193