### PR TITLE
ci: optimize PR builds with minimal matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,8 +180,42 @@ jobs:
           REDIS_URL: redis://localhost:6379
         run: pytest tests/ -v
 
+  # Minimal wheel build for PRs (fast feedback)
   build-wheels:
     name: Build Wheels
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install maturin
+        run: pip install maturin
+
+      - name: Build wheel
+        run: maturin build --release --features python
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheel-ubuntu-py${{ matrix.python-version }}
+          path: target/wheels/*.whl
+
+  # Full wheel build for main branch (complete coverage)
+  build-wheels-full:
+    name: Build Wheels (Full Matrix)
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

Reduces CI time for pull requests by using a minimal build matrix, while keeping full coverage on main branch pushes.

## Changes

| Event | Wheel Builds | Jobs |
|-------|--------------|------|
| **PR** | ubuntu only, Python 3.10 + 3.12 | 2 |
| **Main push** | ubuntu + macos, Python 3.10 + 3.11 + 3.12 | 6 |

## Rationale

- PRs get fast feedback (2 jobs instead of 6)
- Testing min (3.10) and max (3.12) Python versions catches most compatibility issues
- Full matrix still runs on every merge to main, ensuring complete coverage
- macOS builds are less commonly the source of issues and can wait for main