### PR TITLE
feat: add multi-cluster parallel write support

### DIFF
--- a/python/polars_redis/__init__.py
+++ b/python/polars_redis/__init__.py
@@ -97,6 +97,13 @@ from polars_redis._keys import (
     set_ttl,
     set_ttl_from_column,
 )
+from polars_redis._multi import (
+    Destination,
+    DestinationResult,
+    MultiWriteResult,
+    write_hashes_multi,
+    write_json_multi,
+)
 from polars_redis._pipeline import (
     CommandResult,
     Pipeline,
@@ -218,6 +225,12 @@ __all__ = [
     "write_strings",
     "write_zsets",
     "WriteResult",
+    # Multi-cluster write
+    "write_hashes_multi",
+    "write_json_multi",
+    "Destination",
+    "DestinationResult",
+    "MultiWriteResult",
     # Pipeline and Transaction
     "Pipeline",
     "Transaction",

--- a/python/polars_redis/_multi.py
+++ b/python/polars_redis/_multi.py
@@ -1,0 +1,364 @@
+"""Multi-cluster write support for polars-redis.
+
+This module provides functions for writing DataFrames to multiple Redis
+clusters in parallel, enabling fan-out patterns for replication and
+geographic distribution.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+import polars as pl
+
+
+@dataclass
+class Destination:
+    """Configuration for a write destination.
+
+    Attributes:
+        url: Redis connection URL (e.g., "redis://localhost:6379").
+        name: Optional name for this destination (for logging/metrics).
+        key_prefix: Prefix to prepend to all keys (default: "").
+        transform: Optional function to transform the DataFrame before writing.
+        timeout_ms: Timeout for this destination in milliseconds (default: 30000).
+    """
+
+    url: str
+    name: str | None = None
+    key_prefix: str = ""
+    transform: Callable[[pl.DataFrame], pl.DataFrame] | None = None
+    timeout_ms: int = 30000
+
+    def __post_init__(self) -> None:
+        if self.name is None:
+            # Extract host from URL for default name
+            self.name = self.url.split("://")[-1].split("/")[0]
+
+
+@dataclass
+class DestinationResult:
+    """Result of a write operation to a single destination.
+
+    Attributes:
+        destination: The destination configuration.
+        keys_written: Number of keys successfully written.
+        keys_failed: Number of keys that failed to write.
+        success: Whether the write completed without errors.
+        error: Error message if the write failed entirely.
+        duration_ms: Time taken for the write in milliseconds.
+    """
+
+    destination: Destination
+    keys_written: int = 0
+    keys_failed: int = 0
+    success: bool = True
+    error: str | None = None
+    duration_ms: float = 0.0
+
+    def __repr__(self) -> str:
+        status = "ok" if self.success else f"error: {self.error}"
+        return (
+            f"DestinationResult({self.destination.name}: "
+            f"{self.keys_written} written, {self.keys_failed} failed, {status})"
+        )
+
+
+@dataclass
+class MultiWriteResult:
+    """Aggregated result of writing to multiple destinations.
+
+    Attributes:
+        results: List of per-destination results.
+        total_keys_written: Total keys written across all destinations.
+        total_keys_failed: Total keys failed across all destinations.
+        all_succeeded: Whether all destinations completed successfully.
+        failed_destinations: List of destination names that failed.
+    """
+
+    results: list[DestinationResult] = field(default_factory=list)
+
+    @property
+    def total_keys_written(self) -> int:
+        return sum(r.keys_written for r in self.results)
+
+    @property
+    def total_keys_failed(self) -> int:
+        return sum(r.keys_failed for r in self.results)
+
+    @property
+    def all_succeeded(self) -> bool:
+        return all(r.success for r in self.results)
+
+    @property
+    def failed_destinations(self) -> list[str]:
+        return [r.destination.name or r.destination.url for r in self.results if not r.success]
+
+    def __repr__(self) -> str:
+        succeeded = sum(1 for r in self.results if r.success)
+        failed = len(self.results) - succeeded
+        return (
+            f"MultiWriteResult({succeeded}/{len(self.results)} destinations succeeded, "
+            f"{self.total_keys_written} total keys written)"
+        )
+
+
+async def _write_to_destination_hashes(
+    df: pl.DataFrame,
+    dest: Destination,
+    key_column: str | None,
+    ttl: int | None,
+    if_exists: str,
+) -> DestinationResult:
+    """Write DataFrame to a single destination as hashes."""
+    import time
+
+    from polars_redis._internal import py_write_hashes
+
+    start = time.perf_counter()
+    result = DestinationResult(destination=dest)
+
+    try:
+        # Apply transform if provided
+        write_df = dest.transform(df) if dest.transform else df
+
+        # Prepare keys and values
+        if key_column is None:
+            keys = [f"{dest.key_prefix}{i}" for i in range(len(write_df))]
+            field_columns = list(write_df.columns)
+        else:
+            if key_column not in write_df.columns:
+                raise ValueError(f"Key column '{key_column}' not found in DataFrame")
+            keys = [f"{dest.key_prefix}{k}" for k in write_df[key_column].to_list()]
+            field_columns = [c for c in write_df.columns if c != key_column]
+
+        # Convert values to strings
+        values = []
+        for i in range(len(write_df)):
+            row_values = []
+            for col in field_columns:
+                val = write_df[col][i]
+                row_values.append(None if val is None else str(val))
+            values.append(row_values)
+
+        # Run the sync write in a thread pool to not block the event loop
+        loop = asyncio.get_event_loop()
+        keys_written, keys_failed, _ = await asyncio.wait_for(
+            loop.run_in_executor(
+                None,
+                lambda: py_write_hashes(dest.url, keys, field_columns, values, ttl, if_exists),
+            ),
+            timeout=dest.timeout_ms / 1000,
+        )
+
+        result.keys_written = keys_written
+        result.keys_failed = keys_failed
+        result.success = True
+
+    except asyncio.TimeoutError:
+        result.success = False
+        result.error = f"Timeout after {dest.timeout_ms}ms"
+    except Exception as e:
+        result.success = False
+        result.error = str(e)
+
+    result.duration_ms = (time.perf_counter() - start) * 1000
+    return result
+
+
+async def _write_to_destination_json(
+    df: pl.DataFrame,
+    dest: Destination,
+    key_column: str | None,
+    ttl: int | None,
+    if_exists: str,
+) -> DestinationResult:
+    """Write DataFrame to a single destination as JSON."""
+    import time
+
+    from polars_redis._internal import py_write_json
+
+    start = time.perf_counter()
+    result = DestinationResult(destination=dest)
+
+    try:
+        # Apply transform if provided
+        write_df = dest.transform(df) if dest.transform else df
+
+        # Prepare keys and JSON strings
+        if key_column is None:
+            keys = [f"{dest.key_prefix}{i}" for i in range(len(write_df))]
+            field_columns = list(write_df.columns)
+        else:
+            if key_column not in write_df.columns:
+                raise ValueError(f"Key column '{key_column}' not found in DataFrame")
+            keys = [f"{dest.key_prefix}{k}" for k in write_df[key_column].to_list()]
+            field_columns = [c for c in write_df.columns if c != key_column]
+
+        # Build JSON strings
+        json_strings = []
+        for i in range(len(write_df)):
+            doc = {}
+            for col in field_columns:
+                val = write_df[col][i]
+                if val is not None:
+                    doc[col] = val
+            json_strings.append(json.dumps(doc))
+
+        # Run the sync write in a thread pool
+        loop = asyncio.get_event_loop()
+        keys_written, keys_failed, _ = await asyncio.wait_for(
+            loop.run_in_executor(
+                None,
+                lambda: py_write_json(dest.url, keys, json_strings, ttl, if_exists),
+            ),
+            timeout=dest.timeout_ms / 1000,
+        )
+
+        result.keys_written = keys_written
+        result.keys_failed = keys_failed
+        result.success = True
+
+    except asyncio.TimeoutError:
+        result.success = False
+        result.error = f"Timeout after {dest.timeout_ms}ms"
+    except Exception as e:
+        result.success = False
+        result.error = str(e)
+
+    result.duration_ms = (time.perf_counter() - start) * 1000
+    return result
+
+
+async def write_hashes_multi(
+    df: pl.DataFrame,
+    destinations: list[Destination | dict[str, Any]],
+    key_column: str | None = "_key",
+    ttl: int | None = None,
+    if_exists: str = "replace",
+) -> MultiWriteResult:
+    """Write a DataFrame to multiple Redis clusters as hashes in parallel.
+
+    Each destination receives the same DataFrame (optionally transformed),
+    written as Redis hashes. Writes execute concurrently, and failures at
+    one destination don't affect others.
+
+    Args:
+        df: The DataFrame to write.
+        destinations: List of destinations. Each can be a Destination object
+            or a dict with keys: url (required), name, key_prefix, transform, timeout_ms.
+        key_column: Column containing Redis keys (default: "_key").
+            If None, keys are auto-generated from row indices.
+        ttl: Optional TTL in seconds for each key.
+        if_exists: How to handle existing keys ("fail", "replace", "append").
+
+    Returns:
+        MultiWriteResult with per-destination results.
+
+    Example:
+        >>> import polars as pl
+        >>> import polars_redis as pr
+        >>> from polars_redis import Destination
+        >>>
+        >>> df = pl.DataFrame({
+        ...     "id": ["user:1", "user:2"],
+        ...     "name": ["Alice", "Bob"],
+        ...     "region": ["US", "EU"],
+        ... })
+        >>>
+        >>> result = await pr.write_hashes_multi(
+        ...     df,
+        ...     destinations=[
+        ...         Destination(url="redis://cluster-a:6379", key_prefix="primary:"),
+        ...         Destination(url="redis://cluster-b:6379", key_prefix="backup:"),
+        ...     ],
+        ...     key_column="id",
+        ... )
+        >>>
+        >>> print(f"Wrote to {len(result.results)} destinations")
+        >>> for r in result.results:
+        ...     print(f"  {r.destination.name}: {r.keys_written} keys")
+    """
+    # Normalize destinations to Destination objects
+    normalized: list[Destination] = []
+    for dest in destinations:
+        if isinstance(dest, dict):
+            normalized.append(Destination(**dest))
+        else:
+            normalized.append(dest)
+
+    # Write to all destinations in parallel
+    tasks = [
+        _write_to_destination_hashes(df, dest, key_column, ttl, if_exists) for dest in normalized
+    ]
+    results = await asyncio.gather(*tasks, return_exceptions=False)
+
+    return MultiWriteResult(results=list(results))
+
+
+async def write_json_multi(
+    df: pl.DataFrame,
+    destinations: list[Destination | dict[str, Any]],
+    key_column: str | None = "_key",
+    ttl: int | None = None,
+    if_exists: str = "replace",
+) -> MultiWriteResult:
+    """Write a DataFrame to multiple Redis clusters as JSON documents in parallel.
+
+    Each destination receives the same DataFrame (optionally transformed),
+    written as RedisJSON documents. Writes execute concurrently, and failures
+    at one destination don't affect others.
+
+    Args:
+        df: The DataFrame to write.
+        destinations: List of destinations. Each can be a Destination object
+            or a dict with keys: url (required), name, key_prefix, transform, timeout_ms.
+        key_column: Column containing Redis keys (default: "_key").
+            If None, keys are auto-generated from row indices.
+        ttl: Optional TTL in seconds for each key.
+        if_exists: How to handle existing keys ("fail", "replace", "append").
+
+    Returns:
+        MultiWriteResult with per-destination results.
+
+    Example:
+        >>> import polars as pl
+        >>> import polars_redis as pr
+        >>> from polars_redis import Destination
+        >>>
+        >>> df = pl.DataFrame({
+        ...     "id": ["doc:1", "doc:2"],
+        ...     "title": ["Hello", "World"],
+        ...     "views": [100, 200],
+        ... })
+        >>>
+        >>> result = await pr.write_json_multi(
+        ...     df,
+        ...     destinations=[
+        ...         Destination(url="redis://primary:6379"),
+        ...         Destination(url="redis://replica:6379"),
+        ...     ],
+        ...     key_column="id",
+        ... )
+        >>>
+        >>> if not result.all_succeeded:
+        ...     print(f"Failed destinations: {result.failed_destinations}")
+    """
+    # Normalize destinations to Destination objects
+    normalized: list[Destination] = []
+    for dest in destinations:
+        if isinstance(dest, dict):
+            normalized.append(Destination(**dest))
+        else:
+            normalized.append(dest)
+
+    # Write to all destinations in parallel
+    tasks = [
+        _write_to_destination_json(df, dest, key_column, ttl, if_exists) for dest in normalized
+    ]
+    results = await asyncio.gather(*tasks, return_exceptions=False)
+
+    return MultiWriteResult(results=list(results))

--- a/tests/test_multi.py
+++ b/tests/test_multi.py
@@ -1,0 +1,391 @@
+"""Tests for multi-cluster write support."""
+
+from __future__ import annotations
+
+import asyncio
+
+import polars as pl
+import pytest
+
+
+class TestDestination:
+    """Tests for Destination dataclass."""
+
+    def test_destination_defaults(self) -> None:
+        """Test default values for Destination."""
+        from polars_redis import Destination
+
+        dest = Destination(url="redis://localhost:6379")
+
+        assert dest.url == "redis://localhost:6379"
+        assert dest.name == "localhost:6379"  # Extracted from URL
+        assert dest.key_prefix == ""
+        assert dest.transform is None
+        assert dest.timeout_ms == 30000
+
+    def test_destination_with_name(self) -> None:
+        """Test Destination with explicit name."""
+        from polars_redis import Destination
+
+        dest = Destination(url="redis://cluster-a:6379", name="primary")
+
+        assert dest.name == "primary"
+
+    def test_destination_with_transform(self) -> None:
+        """Test Destination with transform function."""
+        from polars_redis import Destination
+
+        def drop_internal(df: pl.DataFrame) -> pl.DataFrame:
+            return df.drop("internal_field")
+
+        dest = Destination(
+            url="redis://localhost:6379",
+            transform=drop_internal,
+        )
+
+        assert dest.transform is not None
+
+        # Test transform works
+        df = pl.DataFrame({"id": [1], "name": ["Alice"], "internal_field": ["secret"]})
+        result = dest.transform(df)
+        assert "internal_field" not in result.columns
+
+
+class TestDestinationResult:
+    """Tests for DestinationResult dataclass."""
+
+    def test_destination_result_repr(self) -> None:
+        """Test DestinationResult string representation."""
+        from polars_redis import Destination, DestinationResult
+
+        dest = Destination(url="redis://localhost:6379", name="primary")
+        result = DestinationResult(
+            destination=dest,
+            keys_written=100,
+            keys_failed=5,
+            success=True,
+        )
+
+        repr_str = repr(result)
+        assert "primary" in repr_str
+        assert "100" in repr_str
+        assert "5" in repr_str
+
+
+class TestMultiWriteResult:
+    """Tests for MultiWriteResult dataclass."""
+
+    def test_multi_write_result_aggregation(self) -> None:
+        """Test MultiWriteResult aggregates correctly."""
+        from polars_redis import Destination, DestinationResult, MultiWriteResult
+
+        dest1 = Destination(url="redis://a:6379", name="a")
+        dest2 = Destination(url="redis://b:6379", name="b")
+
+        result = MultiWriteResult(
+            results=[
+                DestinationResult(destination=dest1, keys_written=100, keys_failed=0, success=True),
+                DestinationResult(destination=dest2, keys_written=80, keys_failed=20, success=True),
+            ]
+        )
+
+        assert result.total_keys_written == 180
+        assert result.total_keys_failed == 20
+        assert result.all_succeeded is True
+        assert len(result.failed_destinations) == 0
+
+    def test_multi_write_result_with_failure(self) -> None:
+        """Test MultiWriteResult with failed destination."""
+        from polars_redis import Destination, DestinationResult, MultiWriteResult
+
+        dest1 = Destination(url="redis://a:6379", name="a")
+        dest2 = Destination(url="redis://b:6379", name="b")
+
+        result = MultiWriteResult(
+            results=[
+                DestinationResult(destination=dest1, keys_written=100, success=True),
+                DestinationResult(
+                    destination=dest2, keys_written=0, success=False, error="Connection refused"
+                ),
+            ]
+        )
+
+        assert result.all_succeeded is False
+        assert result.failed_destinations == ["b"]
+
+
+class TestWriteHashesMulti:
+    """Tests for write_hashes_multi function."""
+
+    @pytest.mark.asyncio
+    async def test_write_hashes_multi_single_destination(
+        self, redis_url: str, redis_available: bool
+    ) -> None:
+        """Test writing to a single destination."""
+        if not redis_available:
+            pytest.skip("Redis not available")
+
+        import polars_redis as pr
+        import redis as redis_client
+
+        df = pl.DataFrame(
+            {
+                "_key": ["multi:hash:1", "multi:hash:2", "multi:hash:3"],
+                "name": ["Alice", "Bob", "Charlie"],
+                "score": [100, 200, 300],
+            }
+        )
+
+        result = await pr.write_hashes_multi(
+            df,
+            destinations=[pr.Destination(url=redis_url, name="test")],
+        )
+
+        assert result.all_succeeded
+        assert result.total_keys_written == 3
+
+        # Verify data was written
+        client = redis_client.from_url(redis_url)
+        try:
+            assert client.hget("multi:hash:1", "name") == b"Alice"
+            assert client.hget("multi:hash:2", "score") == b"200"
+        finally:
+            client.delete("multi:hash:1", "multi:hash:2", "multi:hash:3")
+            client.close()
+
+    @pytest.mark.asyncio
+    async def test_write_hashes_multi_with_key_prefix(
+        self, redis_url: str, redis_available: bool
+    ) -> None:
+        """Test writing with different key prefixes per destination."""
+        if not redis_available:
+            pytest.skip("Redis not available")
+
+        import polars_redis as pr
+        import redis as redis_client
+
+        df = pl.DataFrame(
+            {
+                "_key": ["1", "2"],
+                "value": ["a", "b"],
+            }
+        )
+
+        result = await pr.write_hashes_multi(
+            df,
+            destinations=[
+                pr.Destination(url=redis_url, name="prefix-a", key_prefix="prefix_a:"),
+                pr.Destination(url=redis_url, name="prefix-b", key_prefix="prefix_b:"),
+            ],
+        )
+
+        assert result.all_succeeded
+        assert result.total_keys_written == 4  # 2 keys x 2 destinations
+
+        # Verify both prefixes exist
+        client = redis_client.from_url(redis_url)
+        try:
+            assert client.hget("prefix_a:1", "value") == b"a"
+            assert client.hget("prefix_b:1", "value") == b"a"
+        finally:
+            client.delete("prefix_a:1", "prefix_a:2", "prefix_b:1", "prefix_b:2")
+            client.close()
+
+    @pytest.mark.asyncio
+    async def test_write_hashes_multi_with_transform(
+        self, redis_url: str, redis_available: bool
+    ) -> None:
+        """Test writing with per-destination transform."""
+        if not redis_available:
+            pytest.skip("Redis not available")
+
+        import polars_redis as pr
+        import redis as redis_client
+
+        df = pl.DataFrame(
+            {
+                "_key": ["transform:1"],
+                "name": ["Alice"],
+                "internal": ["secret"],
+            }
+        )
+
+        def drop_internal(df: pl.DataFrame) -> pl.DataFrame:
+            return df.drop("internal")
+
+        result = await pr.write_hashes_multi(
+            df,
+            destinations=[
+                pr.Destination(url=redis_url, name="full", key_prefix="full:"),
+                pr.Destination(
+                    url=redis_url, name="filtered", key_prefix="filtered:", transform=drop_internal
+                ),
+            ],
+        )
+
+        assert result.all_succeeded
+
+        client = redis_client.from_url(redis_url)
+        try:
+            # Full destination has all fields
+            assert client.hget("full:transform:1", "internal") == b"secret"
+            # Filtered destination doesn't have internal field
+            assert client.hget("filtered:transform:1", "internal") is None
+            assert client.hget("filtered:transform:1", "name") == b"Alice"
+        finally:
+            client.delete("full:transform:1", "filtered:transform:1")
+            client.close()
+
+    @pytest.mark.asyncio
+    async def test_write_hashes_multi_dict_destinations(
+        self, redis_url: str, redis_available: bool
+    ) -> None:
+        """Test writing with dict-style destination config."""
+        if not redis_available:
+            pytest.skip("Redis not available")
+
+        import polars_redis as pr
+        import redis as redis_client
+
+        df = pl.DataFrame(
+            {
+                "_key": ["dict:1"],
+                "value": ["test"],
+            }
+        )
+
+        result = await pr.write_hashes_multi(
+            df,
+            destinations=[
+                {"url": redis_url, "name": "dict-dest", "key_prefix": "dict:"},
+            ],
+        )
+
+        assert result.all_succeeded
+
+        client = redis_client.from_url(redis_url)
+        try:
+            assert client.hget("dict:dict:1", "value") == b"test"
+        finally:
+            client.delete("dict:dict:1")
+            client.close()
+
+    @pytest.mark.asyncio
+    async def test_write_hashes_multi_failed_destination(
+        self, redis_url: str, redis_available: bool
+    ) -> None:
+        """Test handling of failed destination."""
+        if not redis_available:
+            pytest.skip("Redis not available")
+
+        import polars_redis as pr
+        import redis as redis_client
+
+        df = pl.DataFrame(
+            {
+                "_key": ["fail:1"],
+                "value": ["test"],
+            }
+        )
+
+        result = await pr.write_hashes_multi(
+            df,
+            destinations=[
+                pr.Destination(url=redis_url, name="good"),
+                pr.Destination(url="redis://nonexistent-host:6379", name="bad", timeout_ms=1000),
+            ],
+        )
+
+        # Good destination should succeed
+        assert result.results[0].success is True
+        assert result.results[0].keys_written == 1
+
+        # Bad destination should fail
+        assert result.results[1].success is False
+        assert result.results[1].error is not None
+        assert "bad" in result.failed_destinations
+
+        assert result.all_succeeded is False
+
+        # Cleanup
+        client = redis_client.from_url(redis_url)
+        try:
+            client.delete("fail:1")
+        finally:
+            client.close()
+
+
+class TestWriteJsonMulti:
+    """Tests for write_json_multi function."""
+
+    @pytest.mark.asyncio
+    async def test_write_json_multi_basic(self, redis_url: str, redis_available: bool) -> None:
+        """Test basic JSON multi-write."""
+        if not redis_available:
+            pytest.skip("Redis not available")
+
+        import json
+
+        import polars_redis as pr
+        import redis as redis_client
+
+        df = pl.DataFrame(
+            {
+                "_key": ["json:multi:1", "json:multi:2"],
+                "title": ["Hello", "World"],
+                "count": [10, 20],
+            }
+        )
+
+        result = await pr.write_json_multi(
+            df,
+            destinations=[pr.Destination(url=redis_url, name="json-test")],
+        )
+
+        assert result.all_succeeded
+        assert result.total_keys_written == 2
+
+        client = redis_client.from_url(redis_url)
+        try:
+            doc1 = client.json().get("json:multi:1")
+            assert doc1["title"] == "Hello"
+            assert doc1["count"] == 10
+        finally:
+            client.delete("json:multi:1", "json:multi:2")
+            client.close()
+
+
+class TestMultiUnit:
+    """Unit tests that don't require Redis."""
+
+    def test_imports(self) -> None:
+        """Test that multi-cluster functions are importable."""
+        from polars_redis import (
+            Destination,
+            DestinationResult,
+            MultiWriteResult,
+            write_hashes_multi,
+            write_json_multi,
+        )
+
+        assert callable(write_hashes_multi)
+        assert callable(write_json_multi)
+        assert Destination is not None
+        assert DestinationResult is not None
+        assert MultiWriteResult is not None
+
+    def test_destination_url_parsing(self) -> None:
+        """Test URL parsing for default name."""
+        from polars_redis import Destination
+
+        # Standard URL
+        dest = Destination(url="redis://my-cluster.example.com:6379")
+        assert dest.name == "my-cluster.example.com:6379"
+
+        # With path
+        dest = Destination(url="redis://localhost:6379/0")
+        assert dest.name == "localhost:6379"
+
+        # With auth (should still extract host)
+        dest = Destination(url="redis://:password@host:6379")
+        assert "host:6379" in dest.name


### PR DESCRIPTION
## Summary

Adds support for writing DataFrames to multiple Redis clusters in parallel, enabling fan-out patterns for replication and geographic distribution.

## New Functions

- `write_hashes_multi()` - Write DataFrame as hashes to multiple destinations
- `write_json_multi()` - Write DataFrame as JSON documents to multiple destinations

## New Types

- `Destination` - Configuration for a write target (url, name, key_prefix, transform, timeout_ms)
- `DestinationResult` - Result from a single destination write
- `MultiWriteResult` - Aggregated results with convenience properties

## Features

- **Parallel execution**: All destinations written concurrently using asyncio
- **Per-destination config**: Different key prefixes, transforms per destination
- **Partial failure handling**: One destination failing doesn't block others
- **Timeout per destination**: Slow clusters don't block the entire operation
- **Transform support**: Reshape data before writing to specific destinations

## Example

```python
import polars_redis as pr
from polars_redis import Destination

df = pl.DataFrame({
    "id": ["user:1", "user:2"],
    "name": ["Alice", "Bob"],
    "region": ["US", "EU"],
})

result = await pr.write_hashes_multi(
    df,
    destinations=[
        Destination(url="redis://primary:6379", key_prefix="prod:"),
        Destination(url="redis://backup:6379", key_prefix="backup:"),
        Destination(
            url="redis://filtered:6379",
            transform=lambda df: df.drop("internal_field"),
        ),
    ],
    key_column="id",
)

print(f"Wrote to {len(result.results)} destinations")
if not result.all_succeeded:
    print(f"Failed: {result.failed_destinations}")
```

## Tests

14 tests covering:
- Single and multiple destinations
- Key prefix handling
- Transform functions
- Dict-style destination config
- Failed destination handling
- JSON writes

Closes #195